### PR TITLE
Enable `jsx-uses-vars` 

### DIFF
--- a/dotfiles/.eslintrc
+++ b/dotfiles/.eslintrc
@@ -115,6 +115,7 @@
     "radix": 2,
     "react/react-in-jsx-scope": 2,
     "react/jsx-uses-react": 1,
+    "react/jsx-uses-vars": 2,
     "strict": [2, "global"],
     "use-isnan": 2,
     "valid-jsdoc": [2, { "prefer": { "return": "returns" } }],


### PR DESCRIPTION
1. It will be turned off in the next version of `eslint-plugin-react`.
2. Several folks have reported `no-used-vars` false-positives with `godaddy-style@2.0.0`. Enabling this resolved that.