### PR TITLE
Avoid need for spurrious `@returns {void}` JSDoc.

### DIFF
--- a/dotfiles/.eslintrc
+++ b/dotfiles/.eslintrc
@@ -117,7 +117,7 @@
     "react/jsx-uses-react": 1,
     "strict": [2, "global"],
     "use-isnan": 2,
-    "valid-jsdoc": [2, { "prefer": { "return": "returns" } }],
+    "valid-jsdoc": [2, { "prefer": { "return": "returns" }, "requireReturn": false }],
     "wrap-iife": 2,
     "yoda": [2, "never"]
   }


### PR DESCRIPTION
See: https://github.com/eslint/eslint/pull/683. Very useful in React components because component lifecycle methods often do not return.