### PR TITLE
Move plugins to normal dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,13 +33,11 @@
     "babel-eslint": "^4.1.3",
     "escope": "^3.4.0",
     "eslint": "^2.1.0",
+    "eslint-plugin-mocha": "^2.0.0",
+    "eslint-plugin-react": "^3.16.1",
+    "eslint-plugin-json": "^1.2.0",
     "fashion-show": "^3.3.0",
     "install": "^0.4.4",
     "jscs": "^2.10.1"
-  },
-  "devDependencies": {
-    "eslint-plugin-mocha": "^2.0.0",
-    "eslint-plugin-react": "^3.16.1",
-    "eslint-plugin-json": "^1.2.0"
   }
 }


### PR DESCRIPTION
If we set the eslint plugins as normal dependencies they will be included in the `node_modules` folder of the consumer and we will be able to avoid having to specify them in the `package.json` (of the consumer, like we do now). This should work with `npm@3`, since dependencies are flattened. For `npm@2`, we still have to include them, so let's keep them as `peerDependencies` as well.