### PR TITLE
Remove arrow-parens style enforcement.

### DIFF
--- a/dist/.eslintrc
+++ b/dist/.eslintrc
@@ -17,7 +17,6 @@
   },
   "rules": {
     "accessor-pairs": 2,
-    "arrow-parens": [2,"as-needed"],
     "arrow-spacing": [2,{"before":true,"after":true}],
     "block-scoped-var": 2,
     "brace-style": [0,"1tbs"],

--- a/dotfiles/.eslintrc
+++ b/dotfiles/.eslintrc
@@ -20,7 +20,6 @@
   },
   "rules": {
     "accessor-pairs": 2,
-    "arrow-parens": [2, "as-needed"],
     "arrow-spacing": [2, { "before": true, "after": true }],
     "block-scoped-var": 2,
     "brace-style": [0, "1tbs"],


### PR DESCRIPTION
I'd like to remove the `arrow-parens` option from the style guide. Removing enforcement of a particular style allows for cases where brevity preferred:

```javascript
arr.map(i => doSomething(i));
```

... as well as providing additional clarity in these scenarios:

```javascript
const someFunction = (name) => { /* ... */ }

export default (foo) => { /* ... */ }
```

instead of the currently enforced:

```javascript
const someFunction = name => { /* ... */ }

export default foo => { /* ... */ }
```

Thoughts?