### PR TITLE
[bug] Fix binPath when using the --es5 option

### DIFF
--- a/bin/eslint
+++ b/bin/eslint
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
 
 // Remove this when es5-fix.js is no longer necessary
-var getConfigDir = require('../es5-config-dir');
+var paths = require('../es5-paths')();
 
 require('fashion-show')({
   commands: 'eslint',
-  configDir: getConfigDir(),
-  targets: process.argv.splice(2)
+  configDir: paths.configDir,
+  targets: process.argv.splice(2),
+  binPath: paths.binPath
 }, function (err, code) {
   if (err) { return process.exit(1); }
   process.exit(code);

--- a/bin/jscs
+++ b/bin/jscs
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
 
 // Remove this when es5-fix.js is no longer necessary
-var getConfigDir = require('../es5-config-dir');
+var paths = require('../es5-paths')();
 
 require('fashion-show')({
   commands: 'jscs',
-  configDir: getConfigDir(),
+  configDir: paths.configDir,
   targets: process.argv.splice(2),
+  binPath: paths.binPath,
   fix: true
 }, function (err, code) {
   if (err) { return process.exit(1); }

--- a/bin/lint
+++ b/bin/lint
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
 
 // Remove this when es5-fix.js is no longer necessary
-var getConfigDir = require('../es5-config-dir');
+var paths = require('../es5-paths')();
 
 require('fashion-show')({
   commands: ['jscs', 'eslint'],
-  configDir: getConfigDir(),
+  configDir: paths.configDir,
   targets: process.argv.splice(2),
+  binPath: paths.binPath,
   fix: true
 }, function (err, code) {
   if (err) { return process.exit(1); }

--- a/es5-paths.js
+++ b/es5-paths.js
@@ -3,18 +3,27 @@
 
 var path = require('path');
 
-module.exports = getConfigDir;
+module.exports = es5Paths;
 
-function getConfigDir() {
+function es5Paths() {
   var args = process.argv.slice(2);
   var es5ArgIndex = args.indexOf('--es5');
   var es5 = es5ArgIndex > -1;
   var configDir = path.join(__dirname, 'dist');
+  // We need to get the binPath here and pass it to fashion-show
+  // because if binPath is not provided, fashion show infers the
+  // the binPath using the configDir, which results in a broken
+  // binPath when using --es5, because the --es5 configDir has one
+  // more level of directory nesting.
+  var binPath = path.join(__dirname, 'node_modules/.bin');
   if(es5) {
     configDir = path.join(configDir, 'es5');
     // We need to remove the --es5 argument because fashion-show
     // will throw an error if it remains
     process.argv.splice(es5ArgIndex + 2, 1);
   }
-  return configDir;
+  return {
+    configDir: configDir,
+    binPath: binPath
+  };
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "godaddy-style",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "The styleguide, lint files, and requireable helpers for consistent style at GoDaddy.",
   "scripts": {
     "pretest": "./bin/lint bin",


### PR DESCRIPTION
This fixes a bug that was introduced in 2.0.3, which caused a broken binPath when using the `--es5` option, due to [this code](https://github.com/indexzero/fashion-show/blob/master/lib/defaultify.js#L53) in fashion-show.  The bug only appears if you don't have `jscs` and `eslint` installed globally (which I did on my development box), or anywhere else on your existing PATH.  It would manifest like this:
```
Error: spawn jscs ENOENT
    at exports._errnoException (util.js:874:11)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:178:32)
    at onErrorNT (internal/child_process.js:344:16)
    at doNTCallback2 (node.js:439:9)
    at process._tickCallback (node.js:353:17)
    at Function.Module.runMain (module.js:469:11)
    at startup (node.js:134:18)
    at node.js:961:3
```