### PR TITLE
Disable consistent return rule

### DIFF
--- a/dotfiles/.eslintrc
+++ b/dotfiles/.eslintrc
@@ -25,7 +25,7 @@
     "brace-style": [0, "1tbs"],
     "callback-return": [2, ["cb", "callback", "next", "done"]],
     "complexity": [1, 11],
-    "consistent-return": 2,
+    "consistent-return": 0,
     "constructor-super": 2,
     "default-case": 2,
     "eqeqeq": 2,


### PR DESCRIPTION
This rule currently prohibits code like the following:
```javascript
function foo(args, cb) {
  someFunction(args, function (err, result) {
    if (err) return void cb(err);
    cb(null, doFurtherProcessing(result));
  });
}
```
and instead insists on:
```javascript
function foo(args, cb) {
  someFunction(args, function (err, result) {
    if (err) return void cb(err);
    return void cb(null, doFurtherProcessing(result));
  });
}
```
The first is a common pattern, is unambiguous, and hasn't lead to any bugs. I don't think this rule provides enough value to justify the additional visual noise added by the second, or the developer time/focus to make the code changes required to pass this rule.