### PR TITLE
remove no-useless-concat rule

### DIFF
--- a/dotfiles/.eslintrc
+++ b/dotfiles/.eslintrc
@@ -108,7 +108,7 @@
     "no-unused-expressions": 0,
     "no-use-before-define": [2, "nofunc"],
     "no-useless-call": 2,
-    "no-useless-concat": 2,
+    "no-useless-concat": 0,
     "no-with": 2,
     "prefer-const": 2,
     "radix": 2,


### PR DESCRIPTION
This rule prevents strings literals from being concatenated. It prevents you from building long strings line by line, though. Code like:
```
var x = "Say I'm formatting a really long string here, " +
          "to pass to a service that takes a textual input, " +
          "or to create a verbose error message in an odd edge case " +
          "and I don't want to make the line length absurdly long";
```
produces an error. Conforming to the rule would make that line of code into
```
var x = "Say I'm formatting a really long string here, to pass to a service that takes a textual input, or to create a verbose error message in an odd edge case and I don't want to make the line length absurdly long";
```
which is much less readable, and also violates other eslint rules (max line length). The [documentation for the rule](http://eslint.org/docs/rules/no-useless-concat) gives the justification that it prevents lines like `var x = 'a' + 'b';`, which may result accidental refactoring, but I've never seen a case like this occur in practice. I think that requiring manually disabling the rule in comments for a relatively common case of producing multiline strings is more distraction/visual noise than its worth to rule out the hypothetical case given in the rule's description.