### PR TITLE
remove 'radix' rule

### DIFF
--- a/dotfiles/.eslintrc
+++ b/dotfiles/.eslintrc
@@ -111,7 +111,7 @@
     "no-useless-concat": 2,
     "no-with": 2,
     "prefer-const": 2,
-    "radix": 2,
+    "radix": 0,
     "react/jsx-uses-react": 1,
     "strict": [2, "global"],
     "use-isnan": 2,


### PR DESCRIPTION
The "radix" rule requires the radix second argument to be passed to calls to `parseInt`.
This means that `parseInt(foo);` is invalid, but `parseInt(foo, 10);` is allowed.

This is to prevent issues in ES4 code where `parseInt` would unexpectedly parse strings with leading zeroes as octal. AFAIK, no one at GoDaddy is actively developing ES4 code though, so this rule doesn't add value.