### PR TITLE
Reduce `prefer-const` to a warning.

### DIFF
--- a/dist/.eslintrc
+++ b/dist/.eslintrc
@@ -107,7 +107,7 @@
     "no-useless-call": 2,
     "no-useless-concat": 2,
     "no-with": 2,
-    "prefer-const": 2,
+    "prefer-const": 1,
     "radix": 2,
     "react/jsx-uses-react": 1,
     "strict": [2,"global"],

--- a/dist/es5/.eslintrc
+++ b/dist/es5/.eslintrc
@@ -187,7 +187,7 @@
     "no-useless-call": 2,
     "no-useless-concat": 2,
     "no-with": 2,
-    "prefer-const": 2,
+    "prefer-const": 1,
     "radix": 2,
     "react/jsx-uses-react": 1,
     "strict": [

--- a/dotfiles/.eslintrc
+++ b/dotfiles/.eslintrc
@@ -110,7 +110,7 @@
     "no-useless-call": 2,
     "no-useless-concat": 2,
     "no-with": 2,
-    "prefer-const": 2,
+    "prefer-const": 1,
     "radix": 2,
     "react/jsx-uses-react": 1,
     "strict": [2, "global"],


### PR DESCRIPTION
There are situations where ESLint cannot determine it is actually not `const`. e.g. ESLint
does not understand the semantics of `mocha`, specifically the `beforeEach`:

``` js
describe('Any test suite', () => {
  let fixture;

  beforeEach(() => {
    fixture = testHelper({ setup: 'some stuff' });
  });

  it('my first test', () => { });
  it('my second test', () => { });
});
```

The above would throw an error for `prefer-const` but fixture is actually
set twice because of how `before` works in `mocha`.