### PR TITLE
Add instructions to override a specific rule locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This section is a place for additional best practices that may be useful but are
 ### How do I override a specific rule ?
 
 1. Add a `.eslintrc` file at the root of your project:
-```
+``` js
 {
   "extends": "./node_modules/godaddy-style/dist/.eslintrc",
   "rules": {

--- a/README.md
+++ b/README.md
@@ -73,6 +73,28 @@ This section is a place for additional best practices that may be useful but are
 
 ## FAQ
 
+### How do I override a specific rule ?
+
+1. Add a `.eslintrc` file at the root of your project:
+```
+{
+  "extends": "./node_modules/godaddy-style/dist/.eslintrc",
+  "rules": {
+    // Disable the 'max-params' rule
+    "max-params": 0
+  }
+}
+```
+
+2. Add a param to specify the path of your own `.eslintrc` file in your `package.json`:
+``` js
+{
+  "scripts": {
+    "eslint": "godaddy-js-style-eslint -c .eslintrc lib/ test/",
+  }
+}
+```
+
 ### How do I contribute?
 
 Fork this repository and submit a pull request.


### PR DESCRIPTION
We have been using GoDaddy's style guide in 4 projects so far and we always encounter the need to override one or two eslint rules.

We struggled quite a bit to understand how to extend and override the provided `.eslintrc` file in `dist`. We thought it would be nice to share our findings with everyone else.

-- The MYA and API teams