### PR TITLE
Disable `react/display-name` for ES6

### DIFF
--- a/dist/.eslintrc
+++ b/dist/.eslintrc
@@ -109,6 +109,7 @@
     "no-with": 2,
     "prefer-const": 1,
     "radix": 2,
+    "react/display-name": 0,
     "react/jsx-uses-react": 1,
     "strict": [2,"global"],
     "use-isnan": 2,

--- a/dist/es5/.eslintrc
+++ b/dist/es5/.eslintrc
@@ -189,6 +189,7 @@
     "no-with": 2,
     "prefer-const": 1,
     "radix": 2,
+    "react/display-name": 2,
     "react/jsx-uses-react": 1,
     "strict": [
       2,

--- a/dotfiles/.eslintrc
+++ b/dotfiles/.eslintrc
@@ -112,6 +112,7 @@
     "no-with": 2,
     "prefer-const": 1,
     "radix": 2,
+    "react/display-name": 0,
     "react/jsx-uses-react": 1,
     "strict": [2, "global"],
     "use-isnan": 2,

--- a/es5/fix.js
+++ b/es5/fix.js
@@ -27,6 +27,9 @@ var es5Options = {
     parserOptions: {
       ecmaVersion: 5,
       sourceType: 'script'
+    },
+    rules: {
+      'react/display-name': 2
     }
   }
 };


### PR DESCRIPTION
Since the recommended way of creating Components is using ES6 classes.