### PR TITLE
Lessen the `no-invalid-this` to a warning

### DIFF
--- a/dist/.eslintrc
+++ b/dist/.eslintrc
@@ -63,7 +63,7 @@
     "no-floating-decimal": 2,
     "no-implied-eval": 2,
     "no-invalid-regexp": 2,
-    "no-invalid-this": 2,
+    "no-invalid-this": 1,
     "no-irregular-whitespace": 0,
     "no-iterator": 2,
     "no-labels": 2,

--- a/dist/es5/.eslintrc
+++ b/dist/es5/.eslintrc
@@ -137,7 +137,7 @@
     "no-floating-decimal": 2,
     "no-implied-eval": 2,
     "no-invalid-regexp": 2,
-    "no-invalid-this": 2,
+    "no-invalid-this": 1,
     "no-irregular-whitespace": 0,
     "no-iterator": 2,
     "no-labels": 2,

--- a/dotfiles/.eslintrc
+++ b/dotfiles/.eslintrc
@@ -67,7 +67,7 @@
     "no-floating-decimal": 2,
     "no-implied-eval": 2,
     "no-invalid-regexp": 2,
-    "no-invalid-this": 2,
+    "no-invalid-this": 1,
     "no-irregular-whitespace": 0,
     "no-iterator": 2,
     "no-labels": 2,


### PR DESCRIPTION
There are a few motivations here:

1.  `this` is valid when binding to class functions in ES6.
2. `this` inside of `describe` for `mocha` (and other test frameworks) is valid.

