### PR TITLE
[fix] Include npm-run-all as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,9 @@
     "eslint-find-rules": "^1.14.3",
     "eslint-plugin-json": "^1.2.0",
     "eslint-plugin-mocha": "^4.8.0",
-    "eslint-plugin-react": "^6.9.0",
-    "npm-run-all": "^4.0.1"
+    "eslint-plugin-react": "^6.9.0"
+  },
+  "dependencies": {
+    "npm-run-all": "^4.0.2"
   }
 }


### PR DESCRIPTION
Fix for #42. The `postinstall` hook of the package uses a `run-p` binary to run various of tasks after the installation of the package. `run-p` is a cli item that is shipped in the `npm-run-all` package which is currently installed as devDependency instead of normal dependency.