### PR TITLE
Indenting case clauses two spaces

### DIFF
--- a/packages/eslint-config-godaddy/index.js
+++ b/packages/eslint-config-godaddy/index.js
@@ -136,7 +136,7 @@ module.exports = {
     'eol-last': 2,
     'key-spacing': 2,
     'func-call-spacing': [2, 'never'],
-    'indent': [2, 2],
+    'indent': [2, 2, { SwitchCase: 1 }],
     'keyword-spacing': 2,
     'linebreak-style': 2,
     'object-curly-spacing': [2, 'always', {


### PR DESCRIPTION
This PR alters eslint's `indent` rule to force `case` clauses within switch statements to be indented two spaces.

For example

```js
switch (action.type) {
case MY_ACTION:
  ...
  break;
default:
  ...
}
```

will now need to be written as

```js
switch (action.type) {
  case MY_ACTION:
    ...
    break;
  default:
    ...
}
```

For more information on `indent`'s options see http://eslint.org/docs/rules/indent