### PR TITLE
Update `array-bracket-spacing` rule

### DIFF
--- a/packages/eslint-config-godaddy/index.js
+++ b/packages/eslint-config-godaddy/index.js
@@ -125,7 +125,7 @@ module.exports = {
     // Whitespace rules follow. All rules are auto-fix unless
     // otherwise specified.
     //
-    'array-bracket-spacing': 2,
+    'array-bracket-spacing': [2, 'always'],
     'brace-style': [2, '1tbs', { allowSingleLine: true }],
     'camelcase': [2, { properties: 'never' }],
     'comma-spacing': 2,


### PR DESCRIPTION
Given we have `object-curly-spacing`  as 'always', shouldn't `array-bracket-spacing` also be 'always' for consistency?

Examples on ESlint's page: http://eslint.org/docs/rules/array-bracket-spacing#always

My personal opinion on this honestly is to do the opposite, I would set `object-curly-spacing: 2` (defaults to 'never').
One way or the other, I think these 2 should be consistent.