### PR TITLE
Sync dependency version from react-flow with other packages

### DIFF
--- a/packages/eslint-config-godaddy-react-flow/package.json
+++ b/packages/eslint-config-godaddy-react-flow/package.json
@@ -26,27 +26,26 @@
     "eslint-godaddy-react-flow": "bin/eslint-godaddy-react-flow"
   },
   "dependencies": {
-    "eslint-config-godaddy-react": "^1.1.0"
+    "eslint-config-godaddy-react": "^1.1.1"
   },
   "peerDependencies": {
-    "eslint": "^3.15.0",
+    "eslint": "^4.3.0",
     "babel-eslint": "^7.2.1",
-    "eslint-find-rules": "^1.14.3",
     "eslint-plugin-babel": "^4.0.1",
     "eslint-plugin-flowtype": "^2.30.4",
     "eslint-plugin-json": "^1.2.0",
     "eslint-plugin-mocha": "^4.8.0",
-    "eslint-plugin-react": "^6.9.0"
+    "eslint-plugin-react": "^7.1.0"
   },
   "license": "MIT",
   "devDependencies": {
-    "eslint": "^3.15.0",
+    "eslint": "^4.3.0",
     "babel-eslint": "^7.2.1",
-    "eslint-find-rules": "^1.14.3",
+    "eslint-find-rules": "^3.1.1",
     "eslint-plugin-babel": "^4.0.1",
     "eslint-plugin-flowtype": "^2.30.4",
     "eslint-plugin-json": "^1.2.0",
     "eslint-plugin-mocha": "^4.8.0",
-    "eslint-plugin-react": "^6.9.0"
+    "eslint-plugin-react": "^7.1.0"
   }
 }

--- a/packages/eslint-config-godaddy-react/package.json
+++ b/packages/eslint-config-godaddy-react/package.json
@@ -31,7 +31,7 @@
     "eslint": "^4.3.0",
     "eslint-plugin-json": "^1.2.0",
     "eslint-plugin-mocha": "^4.8.0",
-    "eslint-plugin-react": "^6.9.0"
+    "eslint-plugin-react": "^7.1.0"
   },
   "license": "MIT",
   "devDependencies": {
@@ -39,6 +39,6 @@
     "eslint-find-rules": "^3.1.1",
     "eslint-plugin-json": "^1.2.0",
     "eslint-plugin-mocha": "^4.8.0",
-    "eslint-plugin-react": "^6.9.0"
+    "eslint-plugin-react": "^7.1.0"
   }
 }


### PR DESCRIPTION
Updating `eslint`, `eslint-find-rules` and `eslint-plugin-react`.
And removing `eslint-find-rules` from `peerDependencies`. It didn't seem appropriate.
Reference: https://github.com/godaddy/javascript/pull/50

@JosephJNK @samshull 