### PR TITLE
bumps eslint-plugin-mocha peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "eslint-plugin-flowtype": "^2.30.4",
     "eslint-find-rules": "^3.1.1",
     "eslint-plugin-json": "^1.2.0",
-    "eslint-plugin-mocha": "^4.8.0",
+    "eslint-plugin-mocha": "^4.11.0",
     "eslint-plugin-react": "^6.9.0"
   },
   "dependencies": {

--- a/packages/eslint-config-godaddy-es5/package.json
+++ b/packages/eslint-config-godaddy-es5/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "eslint": "^4.3.0",
     "eslint-plugin-json": "^1.2.0",
-    "eslint-plugin-mocha": "^4.8.0",
+    "eslint-plugin-mocha": "^4.11.0",
     "eslint-plugin-react": "^6.9.0"
   },
   "license": "MIT",

--- a/packages/eslint-config-godaddy-react-flow/package.json
+++ b/packages/eslint-config-godaddy-react-flow/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-babel": "^4.0.1",
     "eslint-plugin-flowtype": "^2.30.4",
     "eslint-plugin-json": "^1.2.0",
-    "eslint-plugin-mocha": "^4.8.0",
+    "eslint-plugin-mocha": "^4.11.0",
     "eslint-plugin-react": "^7.1.0"
   },
   "license": "MIT",

--- a/packages/eslint-config-godaddy-react/package.json
+++ b/packages/eslint-config-godaddy-react/package.json
@@ -30,7 +30,7 @@
   "peerDependencies": {
     "eslint": "^4.3.0",
     "eslint-plugin-json": "^1.2.0",
-    "eslint-plugin-mocha": "^4.8.0",
+    "eslint-plugin-mocha": "^4.11.0",
     "eslint-plugin-react": "^7.1.0"
   },
   "license": "MIT",

--- a/packages/eslint-config-godaddy/package.json
+++ b/packages/eslint-config-godaddy/package.json
@@ -26,7 +26,7 @@
   "peerDependencies": {
     "eslint": "^4.3.0",
     "eslint-plugin-json": "^1.2.0",
-    "eslint-plugin-mocha": "^4.8.0"
+    "eslint-plugin-mocha": "^4.11.0"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
`eslint-plugin-mocha@4.8.0` has a peer dependency on `eslint@^2.0.0 || ^3.0.0`, which conflicts with the style guide's peer dependency on `eslint@4.3.0`. `eslint-plugin-mocha@4.11.0` has a peer dependency on `eslint@^2.0.0 || ^3.0.0 || ^4.0.0`, fixing the conflict.