### PR TITLE
feat(arrow-fn): require parens

### DIFF
--- a/packages/eslint-config-godaddy/index.js
+++ b/packages/eslint-config-godaddy/index.js
@@ -20,6 +20,7 @@ module.exports = {
   rules: {
     'accessor-pairs': 2,
     'arrow-spacing': [2, { before: true, after: true }],
+    'arrow-parens': [2, 'always'],
     'block-scoped-var': 2,
     'callback-return': [2, ['cb', 'callback', 'next', 'done']],
     'complexity': [1, 11],


### PR DESCRIPTION
To enforce consistency, requires parens for every arrow functions