### PR TITLE
Update ecmaVersion to 8

### DIFF
--- a/packages/eslint-config-godaddy/index.js
+++ b/packages/eslint-config-godaddy/index.js
@@ -2,6 +2,7 @@ module.exports = {
   root: true,
   env: {
     node: true,
+    es6: true,
     browser: true,
     mocha: true,
     phantomjs: true

--- a/packages/eslint-config-godaddy/index.js
+++ b/packages/eslint-config-godaddy/index.js
@@ -2,7 +2,6 @@ module.exports = {
   root: true,
   env: {
     node: true,
-    es6: true,
     browser: true,
     mocha: true,
     phantomjs: true
@@ -10,7 +9,7 @@ module.exports = {
   plugins: ['mocha', 'json'],
   extends: ['eslint:recommended'],
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 8,
     sourceType: 'module',
     ecmaFeatures: {
       globalReturn: true,


### PR DESCRIPTION
Hey there, any reason we can't update ecmaVersion to 8? I'm using async/await, and currently have to override ecmaVersion for eslint to parse these keywords.