### PR TITLE
Enable jsx-equals-spacing

### DIFF
--- a/packages/eslint-config-godaddy-react/index.js
+++ b/packages/eslint-config-godaddy-react/index.js
@@ -14,6 +14,7 @@ module.exports = {
     'react/display-name': 0,
     'react/jsx-pascal-case': [2, { allowAllCaps: true }],
     'react/jsx-uses-react': 1,
+    'react/jsx-equals-spacing': 2,
     'react/prefer-es6-class': 2,
     //
     // Whitespace rules for specific scenarios (e.g. JSX)


### PR DESCRIPTION
Enables `react/jsx-equals-spacing`. The dafault value is "never", so basicaly:

`<Hello name = {firstname} />;` becomes `<Hello name={firstname} />;`

See full doc: https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-equals-spacing.md