### PR TITLE
Reducing react/no-deprecated lint rule to a warning

### DIFF
--- a/packages/eslint-config-godaddy-react/index.js
+++ b/packages/eslint-config-godaddy-react/index.js
@@ -16,6 +16,7 @@ module.exports = {
     'react/jsx-uses-react': 1,
     'react/jsx-equals-spacing': 2,
     'react/prefer-es6-class': 2,
+    'react/no-deprecated': 1,
     //
     // Whitespace rules for specific scenarios (e.g. JSX)
     //


### PR DESCRIPTION
Since `react@16.3` has marked certain functions (`componentWillReceiveProps`, `componentWillMount`, etc.) as deprecated, there is a new lint rule in place that causes errors to be thrown when linting. To give developers time to refactor these cases and prevent the introduction of `eslint-disable` repeatedly, reducing the severity of this rule to a warning seems to be a good corse of action.