### PR TITLE
fix(cli): fix no-shadow warning

### DIFF
--- a/packages/eslint-config-godaddy/cli.js
+++ b/packages/eslint-config-godaddy/cli.js
@@ -36,8 +36,8 @@ module.exports = function (filename) {
       process.argv.splice(2, 0, '-c', require.resolve(filename));
     }
 
-    which('eslint', function (err, resolved) {
-      if (err) { throw err; }
+    which('eslint', function (resolveErr, resolved) {
+      if (resolveErr) { throw resolveErr; }
       require(resolved);
     });
   });


### PR DESCRIPTION
`err` is already declared in line#28  `fs.readdir(cwd, function (err, files) {`