### PR TITLE
[doc] Update the file extension as this example uses JS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ These use _exactly_ the configuration defined in the individual `eslint-config-g
 }
 ```
 
-##### 2. Define your local `.eslintrc` and run `eslint` yourself:
+##### 2. Define your local `.eslintrc.js` and run `eslint` yourself:
 
 ``` js
 module.exports = {


### PR DESCRIPTION
As per title, this example in the readme uses the JavaScript format of eslint and should therefor be referenced to as `.eslintrc.js`