### PR TITLE
Default react version to 'detect'

### DIFF
--- a/packages/eslint-config-godaddy-react/index.js
+++ b/packages/eslint-config-godaddy-react/index.js
@@ -26,5 +26,10 @@ module.exports = {
       spacing: { objectLiterals: 'never' }
     }],
     'jsx-quotes': [2, 'prefer-single']
+  },
+  settings: {
+    react: {
+      version: 'detect'
+    }
   }
 };


### PR DESCRIPTION
Avoids the warning:
`Warning: React version not specified in eslint-plugin-react settings.`