### PR TITLE
Reintroducing react deprecated lint rule

### DIFF
--- a/packages/eslint-config-godaddy-react/CHANGELOG.md
+++ b/packages/eslint-config-godaddy-react/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+- [#79] Reintroduced `react/no-deprecated` lint rule.
+
 ### 4.1.0
 
 - Set react version to 'detect'

--- a/packages/eslint-config-godaddy-react/index.js
+++ b/packages/eslint-config-godaddy-react/index.js
@@ -18,7 +18,6 @@ module.exports = {
     'react/jsx-uses-react': 1,
     'react/jsx-equals-spacing': 2,
     'react/prefer-es6-class': 2,
-    'react/no-deprecated': 1,
     //
     // Whitespace rules for specific scenarios (e.g. JSX)
     //


### PR DESCRIPTION
Now that there has been sufficient time to upgrade to the new react lifecycle methods, we should reintroduce the rule (reverting #65)