### PR TITLE
make readme example match readme instructions

### DIFF
--- a/packages/eslint-config-godaddy-es5/README.md
+++ b/packages/eslint-config-godaddy-es5/README.md
@@ -35,7 +35,7 @@ These use _exactly_ the configuration defined in this  package (`eslint-config-g
 ##### 2. Define your local `.eslintrc` and run `eslint` yourself:
 
 ``` js
-module.exports = {
+{
   // Or for ES5 + React:
   // extends: 'godaddy-es5-react',
   extends: 'godaddy-es5',

--- a/packages/eslint-config-godaddy-es5/README.md
+++ b/packages/eslint-config-godaddy-es5/README.md
@@ -32,10 +32,10 @@ These use _exactly_ the configuration defined in this  package (`eslint-config-g
 }
 ```
 
-##### 2. Define your local `.eslintrc` and run `eslint` yourself:
+##### 2. Define your local `.eslintrc.js` and run `eslint` yourself:
 
 ``` js
-{
+module.exports = {
   // Or for ES5 + React:
   // extends: 'godaddy-es5-react',
   extends: 'godaddy-es5',

--- a/packages/eslint-config-godaddy-react-flow/README.md
+++ b/packages/eslint-config-godaddy-react-flow/README.md
@@ -31,10 +31,10 @@ These use _exactly_ the configuration defined in this  package (`eslint-config-g
 }
 ```
 
-##### 2. Define your local `.eslintrc` and run `eslint` yourself:
+##### 2. Define your local `.eslintrc.js` and run `eslint` yourself:
 
 ``` js
-{
+module.exports = {
   extends: 'godaddy-react-flow',
   rules: {
     //

--- a/packages/eslint-config-godaddy-react-flow/README.md
+++ b/packages/eslint-config-godaddy-react-flow/README.md
@@ -34,7 +34,7 @@ These use _exactly_ the configuration defined in this  package (`eslint-config-g
 ##### 2. Define your local `.eslintrc` and run `eslint` yourself:
 
 ``` js
-module.exports = {
+{
   extends: 'godaddy-react-flow',
   rules: {
     //

--- a/packages/eslint-config-godaddy-react-typescript/README.md
+++ b/packages/eslint-config-godaddy-react-typescript/README.md
@@ -31,10 +31,10 @@ These use _exactly_ the configuration defined in this  package (`eslint-config-g
 }
 ```
 
-##### 2. Define your local `.eslintrc` and run `eslint` yourself:
+##### 2. Define your local `.eslintrc.js` and run `eslint` yourself:
 
 ``` js
-{
+module.exports = {
   extends: 'godaddy-react-typescript',
   rules: {
     //

--- a/packages/eslint-config-godaddy-react-typescript/README.md
+++ b/packages/eslint-config-godaddy-react-typescript/README.md
@@ -34,7 +34,7 @@ These use _exactly_ the configuration defined in this  package (`eslint-config-g
 ##### 2. Define your local `.eslintrc` and run `eslint` yourself:
 
 ``` js
-module.exports = {
+{
   extends: 'godaddy-react-typescript',
   rules: {
     //

--- a/packages/eslint-config-godaddy-react/README.md
+++ b/packages/eslint-config-godaddy-react/README.md
@@ -34,7 +34,7 @@ These use _exactly_ the configuration defined in this  package (`eslint-config-g
 ##### 2. Define your local `.eslintrc` and run `eslint` yourself:
 
 ``` js
-module.exports = {
+{
   extends: 'godaddy-react',
   rules: {
     //

--- a/packages/eslint-config-godaddy-react/README.md
+++ b/packages/eslint-config-godaddy-react/README.md
@@ -31,10 +31,10 @@ These use _exactly_ the configuration defined in this  package (`eslint-config-g
 }
 ```
 
-##### 2. Define your local `.eslintrc` and run `eslint` yourself:
+##### 2. Define your local `.eslintrc.js` and run `eslint` yourself:
 
 ``` js
-{
+module.exports = {
   extends: 'godaddy-react',
   rules: {
     //

--- a/packages/eslint-config-godaddy-typescript/README.md
+++ b/packages/eslint-config-godaddy-typescript/README.md
@@ -31,10 +31,10 @@ These use _exactly_ the configuration defined in this  package (`eslint-config-g
 }
 ```
 
-##### 2. Define your local `.eslintrc` and run `eslint` yourself:
+##### 2. Define your local `.eslintrc.js` and run `eslint` yourself:
 
 ``` js
-{
+module.exports = {
   extends: 'godaddy-typescript',
   rules: {
     //

--- a/packages/eslint-config-godaddy-typescript/README.md
+++ b/packages/eslint-config-godaddy-typescript/README.md
@@ -34,7 +34,7 @@ These use _exactly_ the configuration defined in this  package (`eslint-config-g
 ##### 2. Define your local `.eslintrc` and run `eslint` yourself:
 
 ``` js
-module.exports = {
+{
   extends: 'godaddy-typescript',
   rules: {
     //

--- a/packages/eslint-config-godaddy/README.md
+++ b/packages/eslint-config-godaddy/README.md
@@ -34,7 +34,7 @@ These use _exactly_ the configuration defined in this  package (`eslint-config-g
 ##### 2. Define your local `.eslintrc` and run `eslint` yourself:
 
 ``` js
-module.exports = {
+{
   extends: 'godaddy'
   rules: {
     //

--- a/packages/eslint-config-godaddy/README.md
+++ b/packages/eslint-config-godaddy/README.md
@@ -31,10 +31,10 @@ These use _exactly_ the configuration defined in this  package (`eslint-config-g
 }
 ```
 
-##### 2. Define your local `.eslintrc` and run `eslint` yourself:
+##### 2. Define your local `.eslintrc.js` and run `eslint` yourself:
 
 ``` js
-{
+module.exports = {
   extends: 'godaddy'
   rules: {
     //


### PR DESCRIPTION
ESLint supports configuration files in several formats. The readmes instructed to define `.eslintrc` but gave the example code for `.eslintrc.js`
This PR makes the instruction and example consistent.
https://eslint.org/docs/user-guide/configuring#configuration-file-formats