### PR TITLE
Windows support

### DIFF
--- a/packages/eslint-config-godaddy/cli.js
+++ b/packages/eslint-config-godaddy/cli.js
@@ -1,6 +1,5 @@
 const fs = require('fs');
 const path = require('path');
-const which = require('which');
 
 module.exports = function (filename) {
   filename = filename || path.join(__dirname, 'index');
@@ -36,9 +35,9 @@ module.exports = function (filename) {
       process.argv.splice(2, 0, '-c', require.resolve(filename));
     }
 
-    which('eslint', function (err, resolved) {
-      if (err) { throw err; }
-      require(resolved);
-    });
+    const pkg = require.resolve('eslint/package.json');
+    const bin = path.join(pkg, '..', 'bin', 'eslint.js');
+
+    require(bin);
   });
 };

--- a/packages/eslint-config-godaddy/package.json
+++ b/packages/eslint-config-godaddy/package.json
@@ -29,8 +29,7 @@
   },
   "dependencies": {
     "eslint-plugin-json": "^2.0.1",
-    "eslint-plugin-mocha": "^6.2.2",
-    "which": "^1.2.12"
+    "eslint-plugin-mocha": "^6.2.2"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
As per title, this patch introduces Windows support by directly requiring the `eslint.js` instead of having to deal with dedicated `eslint.cmd` files. This also allows us to lose an additional dependency as the resolving would be done internally by node. 