### PR TITLE
[deps] upgrade mocha plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "eslint": "^8.34.0",
         "eslint-plugin-json": "^3.1.0",
         "eslint-plugin-jsx-a11y": "^6.5.1",
-        "eslint-plugin-mocha": "^10.0.3",
+        "eslint-plugin-mocha": "^10.1.0",
         "eslint-plugin-react": "^7.28.0",
         "react": "^17.0.2",
         "rimraf": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "eslint": "^8.34.0",
     "eslint-plugin-json": "^3.1.0",
     "eslint-plugin-jsx-a11y": "^6.5.1",
-    "eslint-plugin-mocha": "^10.0.3",
+    "eslint-plugin-mocha": "^10.1.0",
     "eslint-plugin-react": "^7.28.0",
     "react": "^17.0.2",
     "rimraf": "^3.0.2",


### PR DESCRIPTION
version 10.0.3 of the mocha plugin uses a rambda version that has a deprecation warning where the functionality has been removed in node 20.