### PR TITLE
Disable react/prop-types

### DIFF
--- a/.changeset/good-laws-play.md
+++ b/.changeset/good-laws-play.md
@@ -1,0 +1,5 @@
+---
+"eslint-config-godaddy-react": minor
+---
+
+Disabling react/prop-types

--- a/packages/eslint-config-godaddy-react/index.js
+++ b/packages/eslint-config-godaddy-react/index.js
@@ -20,6 +20,7 @@ module.exports = {
     'react/jsx-uses-react': 1,
     'react/jsx-equals-spacing': 2,
     'react/prefer-es6-class': 2,
+    'react/prop-types': 0,
     //
     // Whitespace rules for specific scenarios (e.g. JSX)
     //


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary
The `prop-types` package has been deprecated for awhile and checks will be removed from React 19. Are we ok to go ahead and remove this lint rule?
https://react.dev/blog/2024/04/25/react-19-upgrade-guide#removed-proptypes-and-defaultprops

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

**eslint-config-godaddy-react**
- Disable `react/prop-types`

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

React components without `.propTypes` no longer trigger lint errors.

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
