### PR TITLE
[VNEXT-78878] Mercado Pago - add payment authorization call and add the preference id

### DIFF
--- a/.changeset/stupid-papayas-dig.md
+++ b/.changeset/stupid-papayas-dig.md
@@ -1,5 +1,5 @@
 ---
-"@godaddy/react": major
+"@godaddy/react": patch
 ---
 
 This PR adds payment authorization integration to the MercadoPago checkout button component, implementing preference ID generation for brick initialization

--- a/.changeset/stupid-papayas-dig.md
+++ b/.changeset/stupid-papayas-dig.md
@@ -1,0 +1,5 @@
+---
+"@godaddy/react": major
+---
+
+This PR adds payment authorization integration to the MercadoPago checkout button component, implementing preference ID generation for brick initialization

--- a/packages/react/src/components/checkout/payment/checkout-buttons/mercadopago/mercadopago.tsx
+++ b/packages/react/src/components/checkout/payment/checkout-buttons/mercadopago/mercadopago.tsx
@@ -161,7 +161,7 @@ export function MercadoPagoCheckoutButton() {
                   }
                 },
                 onError: () => {
-                  setError(t.errors.errorProcessingPayment);
+                  setError(t.errors.failedToInitializePayment);
                   setIsLoading(false);
                 },
               },
@@ -169,7 +169,7 @@ export function MercadoPagoCheckoutButton() {
 
             setIsBrickReady(true);
           } catch (_err) {
-            setError(t.errors.errorProcessingPayment);
+            setError(t.errors.failedToInitializePayment);
             setIsBrickReady(false);
             brickCreationPromise = null;
           }
@@ -198,7 +198,7 @@ export function MercadoPagoCheckoutButton() {
     isMercadoPagoLoaded,
     mercadoPagoConfig?.publicKey,
     elementId,
-    t.errors.errorProcessingPayment,
+    t.errors.failedToInitializePayment,
   ]);
 
   const handleClick = async () => {

--- a/packages/react/src/components/checkout/payment/checkout-buttons/mercadopago/mercadopago.tsx
+++ b/packages/react/src/components/checkout/payment/checkout-buttons/mercadopago/mercadopago.tsx
@@ -43,8 +43,7 @@ export function MercadoPagoCheckoutButton() {
   const authorizeCheckout = useAuthorizeCheckout();
 
   const [error, setError] = useState('');
-  const [isLoading, setIsLoading] = useState(false);
-  const [isBrickReady, setIsBrickReady] = useState(!!brickController);
+  const [isBrickReady, setIsBrickReady] = useState(false);
   const elementId = 'mercadopago-brick-container';
 
   const getPreferenceId = async () => {
@@ -100,11 +99,10 @@ export function MercadoPagoCheckoutButton() {
 
     if (canInitialize) {
       if (brickController) {
-        // Brick already exists, just mark as ready
+        // Brick already exists, onReady callback will mark as ready
         setIsBrickReady(true);
       } else if (brickCreationPromise) {
-        // Brick creation in progress, wait for it
-        brickCreationPromise.then(() => setIsBrickReady(true));
+        // Brick creation in progress, onReady/onError callbacks will handle state
       } else {
         // Create new brick
         const renderBrick = async () => {
@@ -149,7 +147,7 @@ export function MercadoPagoCheckoutButton() {
               },
               callbacks: {
                 onReady: () => {
-                  setIsLoading(false);
+                  setIsBrickReady(true);
                   const brickContainer = document.getElementById(elementId);
                   const formElement = brickContainer?.querySelector('form');
                   if (formElement) {
@@ -162,12 +160,11 @@ export function MercadoPagoCheckoutButton() {
                 },
                 onError: () => {
                   setError(t.errors.failedToInitializePayment);
-                  setIsLoading(false);
+                  setIsBrickReady(false);
                 },
               },
             });
 
-            setIsBrickReady(true);
           } catch (_err) {
             setError(t.errors.failedToInitializePayment);
             setIsBrickReady(false);
@@ -229,9 +226,16 @@ export function MercadoPagoCheckoutButton() {
           size='lg'
           type='button'
           onClick={handleClick}
-          disabled={isPaymentDisabled || isLoading || !isBrickReady}
+          disabled={isPaymentDisabled || authorizeCheckout.isPending || !isBrickReady}
         >
-          {t.payment.payNow}
+          {authorizeCheckout.isPending && !error ? (
+            <>
+              <LoaderCircle className='h-5 w-5 animate-spin' />
+              {t.payment.payNow}
+            </>
+          ) : (
+            t.payment.payNow
+          )}
         </Button>
       ) : (
         <Button

--- a/packages/react/src/components/checkout/payment/checkout-buttons/mercadopago/mercadopago.tsx
+++ b/packages/react/src/components/checkout/payment/checkout-buttons/mercadopago/mercadopago.tsx
@@ -159,8 +159,12 @@ export function MercadoPagoCheckoutButton() {
                   }
                 },
                 onError: () => {
-                  setError(t.errors.failedToInitializePayment);
-                  setIsBrickReady(false);
+                  // Only treat as initialization failure if the brick never became ready.
+                  // Card validation errors are handled by the brick's own UI.
+                  if (!brickController) {
+                    setError(t.errors.failedToInitializePayment);
+                    setIsBrickReady(false);
+                  }
                 },
               },
             });

--- a/packages/react/src/components/checkout/payment/checkout-buttons/mercadopago/mercadopago.tsx
+++ b/packages/react/src/components/checkout/payment/checkout-buttons/mercadopago/mercadopago.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/components/checkout/payment/utils/use-confirm-checkout';
 import { useIsPaymentDisabled } from '@/components/checkout/payment/utils/use-is-payment-disabled';
 import { useLoadMercadoPago } from '@/components/checkout/payment/utils/use-load-mercadopago';
+import { useAuthorizeCheckout } from '@/components/checkout/payment/utils/use-authorize-checkout';
 import { formatCurrency } from '@/components/checkout/utils/format-currency';
 import { Button } from '@/components/ui/button';
 import { useGoDaddyContext } from '@/godaddy-provider';
@@ -39,11 +40,21 @@ export function MercadoPagoCheckoutButton() {
   const form = useFormContext();
   const { isMercadoPagoLoaded } = useLoadMercadoPago();
   const confirmCheckout = useConfirmCheckout();
+  const authorizeCheckout = useAuthorizeCheckout();
 
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [isBrickReady, setIsBrickReady] = useState(!!brickController);
   const elementId = 'mercadopago-brick-container';
+
+  const getPreferenceId = async () => {
+    const response = await authorizeCheckout.mutateAsync({
+      paymentToken: '',
+      paymentType: PaymentMethodType.MERCADOPAGO,
+      paymentProvider: PaymentProvider.MERCADOPAGO,
+    });
+    return response?.transactionRefNum;
+  }
 
   const handleSubmit = useCallback(
     async ({ formData }: any) => {
@@ -115,10 +126,13 @@ export function MercadoPagoCheckoutButton() {
 
             const { bricksBuilderInstance: bricksBuilder } =
               getMercadoPagoInstance(mercadoPagoConfig.publicKey);
+            
+            const mercadoPagoPreferenceId = await getPreferenceId();
 
             brickController = await bricksBuilder.create('payment', elementId, {
               initialization: {
                 amount: total,
+                preferenceId: mercadoPagoPreferenceId,
                 payer: { email: 'dummy@testuser.com' },
               },
               customization: {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

This PR adds payment authorization integration to the MercadoPago checkout button component, implementing preference ID generation for brick initialization.

What's changing
New `getPreferenceId()` function: Async helper that calls the authorization workflow to retrieve the MercadoPago preference ID

Calls `authorizeCheckout.mutateAsync()` with MercadoPago payment type and provider
Returns transactionRefNum as the preference ID for brick configuration
Preference ID integration: Passes the generated preference ID to the brick initialization

Preference ID is fetched during brick setup in renderBrick()
Included in the brick's initialization config for proper MercadoPago payment processing


## Changeset

<!--
Help reviewers and the release process by included a changeset entry.
Use `pnpm run changeset` and follow the prompts to create a changeset.
-->

- [X] Changeset added ([docs](https://github.com/godaddy/javascript#submit-a-changeset))

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
