### PR TITLE
Add experimental rule for Gopay appId override

### DIFF
--- a/.changeset/stale-spoons-brake.md
+++ b/.changeset/stale-spoons-brake.md
@@ -1,0 +1,5 @@
+---
+"@godaddy/react": patch
+---
+
+Add gopay appId override experimental rule

--- a/packages/react/src/components/checkout/order/use-update-order.test.ts
+++ b/packages/react/src/components/checkout/order/use-update-order.test.ts
@@ -134,7 +134,11 @@ describe('useUpdateOrder - Tax calculation address logic', () => {
 
   describe('Edge cases', () => {
     it('should handle pickupLocationId being undefined for pickup', () => {
-      const result = getTaxDestinationAddress('PICKUP', undefined, mockLocations);
+      const result = getTaxDestinationAddress(
+        'PICKUP',
+        undefined,
+        mockLocations
+      );
 
       expect(result).toBeUndefined();
     });

--- a/packages/react/src/components/checkout/payment/checkout-buttons/applePay/godaddy.tsx
+++ b/packages/react/src/components/checkout/payment/checkout-buttons/applePay/godaddy.tsx
@@ -6,6 +6,7 @@ import type {
   TokenizeJs,
   WalletError,
 } from '@/components/checkout/payment/types';
+import { getApplicationId } from '@/components/checkout/payment/utils/get-application-id';
 import { useBuildPaymentRequest } from '@/components/checkout/payment/utils/use-build-payment-request';
 import {
   PaymentProvider,
@@ -90,7 +91,10 @@ export function GoDaddyApplePayCheckoutButton() {
           businessId: godaddyPaymentsConfig?.businessId || session?.businessId,
           storeId: session?.storeId,
           channelId: session?.channelId,
-          applicationId: godaddyPaymentsConfig?.appId,
+          applicationId: getApplicationId(
+            session,
+            godaddyPaymentsConfig?.appId
+          ),
         },
         {
           country: countryCode,

--- a/packages/react/src/components/checkout/payment/checkout-buttons/express/godaddy.tsx
+++ b/packages/react/src/components/checkout/payment/checkout-buttons/express/godaddy.tsx
@@ -14,6 +14,7 @@ import type {
   WalletError,
   WalletRequestUpdate,
 } from '@/components/checkout/payment/types';
+import { getApplicationId } from '@/components/checkout/payment/utils/get-application-id';
 import {
   type PoyntExpressRequest,
   useBuildPaymentRequest,
@@ -438,7 +439,10 @@ export function ExpressCheckoutButton() {
           businessId: godaddyPaymentsConfig?.businessId || session?.businessId,
           storeId: session?.storeId,
           channelId: session?.channelId,
-          applicationId: godaddyPaymentsConfig?.appId,
+          applicationId: getApplicationId(
+            session,
+            godaddyPaymentsConfig?.appId
+          ),
         },
         {
           country: countryCode,

--- a/packages/react/src/components/checkout/payment/checkout-buttons/googlePay/godaddy.tsx
+++ b/packages/react/src/components/checkout/payment/checkout-buttons/googlePay/godaddy.tsx
@@ -6,6 +6,7 @@ import type {
   TokenizeJs,
   WalletError,
 } from '@/components/checkout/payment/types';
+import { getApplicationId } from '@/components/checkout/payment/utils/get-application-id';
 import { useBuildPaymentRequest } from '@/components/checkout/payment/utils/use-build-payment-request';
 import {
   PaymentProvider,
@@ -90,7 +91,10 @@ export function GoDaddyGooglePayCheckoutButton() {
           businessId: godaddyPaymentsConfig?.businessId || session?.businessId,
           storeId: session?.storeId,
           channelId: session?.channelId,
-          applicationId: godaddyPaymentsConfig?.appId,
+          applicationId: getApplicationId(
+            session,
+            godaddyPaymentsConfig?.appId
+          ),
         },
         {
           country: countryCode,

--- a/packages/react/src/components/checkout/payment/checkout-buttons/mercadopago/mercadopago.tsx
+++ b/packages/react/src/components/checkout/payment/checkout-buttons/mercadopago/mercadopago.tsx
@@ -3,13 +3,13 @@ import React, { useCallback, useLayoutEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { useCheckoutContext } from '@/components/checkout/checkout';
 import { useDraftOrderTotals } from '@/components/checkout/order/use-draft-order';
+import { useAuthorizeCheckout } from '@/components/checkout/payment/utils/use-authorize-checkout';
 import {
   PaymentProvider,
   useConfirmCheckout,
 } from '@/components/checkout/payment/utils/use-confirm-checkout';
 import { useIsPaymentDisabled } from '@/components/checkout/payment/utils/use-is-payment-disabled';
 import { useLoadMercadoPago } from '@/components/checkout/payment/utils/use-load-mercadopago';
-import { useAuthorizeCheckout } from '@/components/checkout/payment/utils/use-authorize-checkout';
 import { formatCurrency } from '@/components/checkout/utils/format-currency';
 import { Button } from '@/components/ui/button';
 import { useGoDaddyContext } from '@/godaddy-provider';
@@ -53,7 +53,7 @@ export function MercadoPagoCheckoutButton() {
       paymentProvider: PaymentProvider.MERCADOPAGO,
     });
     return response?.transactionRefNum;
-  }
+  };
 
   const handleSubmit = useCallback(
     async ({ formData }: any) => {
@@ -124,7 +124,7 @@ export function MercadoPagoCheckoutButton() {
 
             const { bricksBuilderInstance: bricksBuilder } =
               getMercadoPagoInstance(mercadoPagoConfig.publicKey);
-            
+
             const mercadoPagoPreferenceId = await getPreferenceId();
 
             brickController = await bricksBuilder.create('payment', elementId, {
@@ -168,7 +168,6 @@ export function MercadoPagoCheckoutButton() {
                 },
               },
             });
-
           } catch (_err) {
             setError(t.errors.failedToInitializePayment);
             setIsBrickReady(false);
@@ -230,7 +229,9 @@ export function MercadoPagoCheckoutButton() {
           size='lg'
           type='button'
           onClick={handleClick}
-          disabled={isPaymentDisabled || authorizeCheckout.isPending || !isBrickReady}
+          disabled={
+            isPaymentDisabled || authorizeCheckout.isPending || !isBrickReady
+          }
         >
           {authorizeCheckout.isPending && !error ? (
             <>

--- a/packages/react/src/components/checkout/payment/checkout-buttons/paze/godaddy.tsx
+++ b/packages/react/src/components/checkout/payment/checkout-buttons/paze/godaddy.tsx
@@ -6,6 +6,7 @@ import type {
   TokenizeJs,
   WalletError,
 } from '@/components/checkout/payment/types';
+import { getApplicationId } from '@/components/checkout/payment/utils/get-application-id';
 import { useBuildPaymentRequest } from '@/components/checkout/payment/utils/use-build-payment-request';
 import {
   PaymentProvider,
@@ -89,7 +90,10 @@ export function PazeCheckoutButton() {
           businessId: godaddyPaymentsConfig?.businessId || session?.businessId,
           storeId: session?.storeId,
           channelId: session?.channelId,
-          applicationId: godaddyPaymentsConfig?.appId,
+          applicationId: getApplicationId(
+            session,
+            godaddyPaymentsConfig?.appId
+          ),
         },
         {
           country: countryCode,

--- a/packages/react/src/components/checkout/payment/payment-form.tsx
+++ b/packages/react/src/components/checkout/payment/payment-form.tsx
@@ -28,6 +28,7 @@ import {
   PaymentMethodRenderer,
 } from '@/components/checkout/payment/payment-method-renderer';
 import type { TokenizeJs } from '@/components/checkout/payment/types';
+import { getApplicationId } from '@/components/checkout/payment/utils/get-application-id';
 import { PaymentAddressToggle } from '@/components/checkout/payment/utils/payment-address-toggle';
 import { useGetSelectedPaymentMethod } from '@/components/checkout/payment/utils/use-get-selected-payment-method';
 import { useLoadPoyntCollect } from '@/components/checkout/payment/utils/use-load-poynt-collect';
@@ -184,7 +185,10 @@ export function PaymentForm(
           businessId: godaddyPaymentsConfig?.businessId || session?.businessId,
           storeId: session?.storeId,
           channelId: session?.channelId,
-          applicationId: godaddyPaymentsConfig?.appId,
+          applicationId: getApplicationId(
+            session,
+            godaddyPaymentsConfig?.appId
+          ),
         },
         {
           country: countryCode,

--- a/packages/react/src/components/checkout/payment/payment-methods/credit-card/godaddy.tsx
+++ b/packages/react/src/components/checkout/payment/payment-methods/credit-card/godaddy.tsx
@@ -4,6 +4,7 @@ import type {
   TokenizeJs,
   TokenizeJsEvent,
 } from '@/components/checkout/payment/types';
+import { getApplicationId } from '@/components/checkout/payment/utils/get-application-id';
 import { usePoyntCollect } from '@/components/checkout/payment/utils/poynt-provider';
 import {
   PaymentProvider,
@@ -199,7 +200,7 @@ export function GoDaddyCreditCardForm() {
       businessId: godaddyPaymentsConfig?.businessId || session?.businessId,
       storeId: session?.storeId,
       channelId: session?.channelId,
-      applicationId: godaddyPaymentsConfig?.appId,
+      applicationId: getApplicationId(session, godaddyPaymentsConfig?.appId),
     });
 
     collect?.current?.on('ready', () => {

--- a/packages/react/src/components/checkout/payment/utils/get-application-id.ts
+++ b/packages/react/src/components/checkout/payment/utils/get-application-id.ts
@@ -1,0 +1,17 @@
+import type { CheckoutSession } from '@/types';
+
+/**
+ * Resolves the applicationId for TokenizeJs initialization.
+ * When the session has `experimental_rules.gopay_override` enabled,
+ * the goPayAppId from that rule takes precedence over the default appId.
+ */
+export function getApplicationId(
+  session: CheckoutSession | null | undefined,
+  defaultAppId: string | undefined
+): string | undefined {
+  const goPayOverride = session?.experimental_rules?.gopay_override;
+  if (goPayOverride?.enabled && goPayOverride?.goPayAppId) {
+    return goPayOverride.goPayAppId;
+  }
+  return defaultAppId;
+}

--- a/packages/react/src/lib/godaddy/checkout-env.ts
+++ b/packages/react/src/lib/godaddy/checkout-env.ts
@@ -1364,6 +1364,146 @@ const introspection = {
         interfaces: [],
       },
       {
+        kind: 'INPUT_OBJECT',
+        name: 'CheckoutCustomerAddressInput',
+        inputFields: [
+          {
+            name: 'addressLine1',
+            type: {
+              kind: 'SCALAR',
+              name: 'String',
+            },
+          },
+          {
+            name: 'addressLine2',
+            type: {
+              kind: 'SCALAR',
+              name: 'String',
+            },
+          },
+          {
+            name: 'addressLine3',
+            type: {
+              kind: 'SCALAR',
+              name: 'String',
+            },
+          },
+          {
+            name: 'adminArea1',
+            type: {
+              kind: 'SCALAR',
+              name: 'String',
+            },
+          },
+          {
+            name: 'adminArea2',
+            type: {
+              kind: 'SCALAR',
+              name: 'String',
+            },
+          },
+          {
+            name: 'adminArea3',
+            type: {
+              kind: 'SCALAR',
+              name: 'String',
+            },
+          },
+          {
+            name: 'adminArea4',
+            type: {
+              kind: 'SCALAR',
+              name: 'String',
+            },
+          },
+          {
+            name: 'countryCode',
+            type: {
+              kind: 'SCALAR',
+              name: 'String',
+            },
+          },
+          {
+            name: 'postalCode',
+            type: {
+              kind: 'SCALAR',
+              name: 'String',
+            },
+          },
+        ],
+        isOneOf: false,
+      },
+      {
+        kind: 'INPUT_OBJECT',
+        name: 'CheckoutCustomerContactInput',
+        inputFields: [
+          {
+            name: 'address',
+            type: {
+              kind: 'INPUT_OBJECT',
+              name: 'CheckoutCustomerAddressInput',
+            },
+          },
+          {
+            name: 'companyName',
+            type: {
+              kind: 'SCALAR',
+              name: 'String',
+            },
+          },
+          {
+            name: 'email',
+            type: {
+              kind: 'SCALAR',
+              name: 'String',
+            },
+          },
+          {
+            name: 'firstName',
+            type: {
+              kind: 'SCALAR',
+              name: 'String',
+            },
+          },
+          {
+            name: 'lastName',
+            type: {
+              kind: 'SCALAR',
+              name: 'String',
+            },
+          },
+          {
+            name: 'phone',
+            type: {
+              kind: 'SCALAR',
+              name: 'String',
+            },
+          },
+        ],
+        isOneOf: false,
+      },
+      {
+        kind: 'INPUT_OBJECT',
+        name: 'CheckoutCustomerInput',
+        inputFields: [
+          {
+            name: 'billing',
+            type: {
+              kind: 'INPUT_OBJECT',
+              name: 'CheckoutCustomerContactInput',
+            },
+          },
+          {
+            name: 'shipping',
+            type: {
+              kind: 'INPUT_OBJECT',
+              name: 'CheckoutCustomerContactInput',
+            },
+          },
+        ],
+        isOneOf: false,
+      },
+      {
         kind: 'OBJECT',
         name: 'CheckoutSession',
         fields: [
@@ -2605,6 +2745,15 @@ const introspection = {
             isDeprecated: false,
           },
           {
+            name: 'gopay_override',
+            type: {
+              kind: 'OBJECT',
+              name: 'CheckoutSessionGoPayOverrideRule',
+            },
+            args: [],
+            isDeprecated: false,
+          },
+          {
             name: 'localDelivery',
             type: {
               kind: 'OBJECT',
@@ -2625,6 +2774,13 @@ const introspection = {
             type: {
               kind: 'INPUT_OBJECT',
               name: 'CheckoutSessionFreeShippingRuleInput',
+            },
+          },
+          {
+            name: 'gopay_override',
+            type: {
+              kind: 'INPUT_OBJECT',
+              name: 'CheckoutSessionGoPayOverrideRuleInput',
             },
           },
         ],
@@ -2709,6 +2865,64 @@ const introspection = {
               ofType: {
                 kind: 'SCALAR',
                 name: 'Float',
+              },
+            },
+          },
+        ],
+        isOneOf: false,
+      },
+      {
+        kind: 'OBJECT',
+        name: 'CheckoutSessionGoPayOverrideRule',
+        fields: [
+          {
+            name: 'enabled',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'SCALAR',
+                name: 'Boolean',
+              },
+            },
+            args: [],
+            isDeprecated: false,
+          },
+          {
+            name: 'goPayAppId',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'SCALAR',
+                name: 'String',
+              },
+            },
+            args: [],
+            isDeprecated: false,
+          },
+        ],
+        interfaces: [],
+      },
+      {
+        kind: 'INPUT_OBJECT',
+        name: 'CheckoutSessionGoPayOverrideRuleInput',
+        inputFields: [
+          {
+            name: 'enabled',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'SCALAR',
+                name: 'Boolean',
+              },
+            },
+          },
+          {
+            name: 'goPayAppId',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'SCALAR',
+                name: 'String',
               },
             },
           },
@@ -7204,6 +7418,13 @@ const introspection = {
             type: {
               kind: 'SCALAR',
               name: 'String',
+            },
+          },
+          {
+            name: 'customer',
+            type: {
+              kind: 'INPUT_OBJECT',
+              name: 'CheckoutCustomerInput',
             },
           },
           {

--- a/packages/react/src/lib/godaddy/checkout-mutations.ts
+++ b/packages/react/src/lib/godaddy/checkout-mutations.ts
@@ -62,6 +62,10 @@ export const CreateCheckoutSessionMutation = graphql(`
           enabled
             minimumOrderTotal
         }
+        gopay_override {
+          enabled
+          goPayAppId
+        }
       }
       shipping {
         originAddress {

--- a/packages/react/src/lib/godaddy/checkout-queries.ts
+++ b/packages/react/src/lib/godaddy/checkout-queries.ts
@@ -62,6 +62,10 @@ export const GetCheckoutSessionQuery = graphql(`
                 enabled
                   minimumOrderTotal
               }
+              gopay_override {
+                enabled
+                goPayAppId
+              }
             }
             shipping {
               originAddress {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary
                                                                                                                                                                                              
                                                                                                                                                                                                           
 When a checkout session includes experimental_rules.gopay_override with enabled: true, the applicationId passed to all TokenizeJs instances is now overridden with the goPayAppId from that rule. This    
 allows GoPay to be used as the payment application without changing the existing godaddyPaymentsConfig.appId.                                                                                             
                                                                                                                                                                                                           
## Changes                                                                                                                                                                                                   
                                                                                                                                                                                                           
 ### GraphQL Queries                                                                                                                                                                                       
                                                                                                                                                                                                           
 - checkout-queries.ts / checkout-mutations.ts — Added gopay_override { enabled, goPayAppId } to the experimental_rules selection set so the override config is fetched from the session.                  
                                                                                                                                                                                                           
 ### New Utility                                                                                                                                                                                           
                                                                                                                                                                                                           
 - payment/utils/get-application-id.ts — Shared helper that resolves the applicationId for TokenizeJs. Returns goPayAppId when the override is enabled, otherwise falls back to the default                
 godaddyPaymentsConfig.appId.      

## Changeset

<!--
Help reviewers and the release process by included a changeset entry.
Use `pnpm run changeset` and follow the prompts to create a changeset.
-->

- [X] Changeset added ([docs](https://github.com/godaddy/javascript#submit-a-changeset))

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
