### PR TITLE
fix(checkout): only require name for free pickup orders

### DIFF
--- a/.changeset/fix-free-pickup-validation.md
+++ b/.changeset/fix-free-pickup-validation.md
@@ -1,0 +1,5 @@
+---
+"@godaddy/react": patch
+---
+
+Fix "Complete your free order" button not working for free pickup orders. Now only requires billing first and last name instead of full billing address.

--- a/packages/react/src/components/checkout/address/address-form.tsx
+++ b/packages/react/src/components/checkout/address/address-form.tsx
@@ -52,7 +52,13 @@ import { eventIds } from '@/tracking/events';
 import { TrackingEventType, track } from '@/tracking/track';
 import type { Address } from '@/types';
 
-export function AddressForm({ sectionKey }: { sectionKey: string }) {
+interface AddressFormProps {
+  sectionKey: string;
+  /** When true, only show first name and last name fields (used for free pickup orders) */
+  onlyNames?: boolean;
+}
+
+export function AddressForm({ sectionKey, onlyNames = false }: AddressFormProps) {
   const form = useFormContext();
   const { session } = useCheckoutContext();
   const { t } = useGoDaddyContext();
@@ -303,126 +309,131 @@ export function AddressForm({ sectionKey }: { sectionKey: string }) {
 
   return (
     <fieldset className='space-y-2' disabled={isConfirmingCheckout}>
-      <FormField
-        control={form.control}
-        name={`${sectionKey}CountryCode`}
-        render={({ field, fieldState }) => (
-          <FormItem className='flex flex-col'>
-            <FormLabel className='sr-only'>{t.shipping.country}</FormLabel>
-            <Popover
-              open={isCountrySelectOpen}
-              onOpenChange={setCountrySelectOpen}
-            >
-              <PopoverTrigger asChild>
-                <FormControl>
-                  <Button
-                    ref={countryTriggerRef}
-                    variant='outline'
-                    className={cn(
-                      'rounded-md shadow-none justify-between px-3 font-normal hover:bg-muted bg-card active:ring h-12',
-                      !field.value && 'text-muted-foreground'
-                    )}
-                    hasError={!!fieldState.error}
-                    disabled={isConfirmingCheckout}
-                    aria-required={requiredFields?.[`${sectionKey}CountryCode`]}
-                    tabIndex={0}
-                  >
-                    {field.value
-                      ? countries.find(country => country.value === field.value)
-                          ?.label
-                      : t.shipping.selectCountry}
-                    <ChevronsUpDown className='opacity-50' />
-                  </Button>
-                </FormControl>
-              </PopoverTrigger>
-              <PopoverContent
-                className='p-0 rounded-md'
-                style={{
-                  width: triggerWidth ? `${triggerWidth + 2}px` : '100%',
-                }}
+      {!onlyNames && (
+        <FormField
+          control={form.control}
+          name={`${sectionKey}CountryCode`}
+          render={({ field, fieldState }) => (
+            <FormItem className='flex flex-col'>
+              <FormLabel className='sr-only'>{t.shipping.country}</FormLabel>
+              <Popover
+                open={isCountrySelectOpen}
+                onOpenChange={setCountrySelectOpen}
               >
-                <Command>
-                  <CommandInput
-                    placeholder={t.shipping.searchCountry}
-                    className='h-12'
-                    disabled={isConfirmingCheckout}
-                  />
-                  <CommandList>
-                    <CommandEmpty>{t.shipping.noCountryFound}</CommandEmpty>
-                    <CommandGroup>
-                      {countries.map(country => (
-                        <CommandItem
-                          value={country.label}
-                          key={country.value}
-                          onSelect={() => {
-                            // Get current country before setting the new one
-                            const previousCountry = form.getValues(
-                              `${sectionKey}CountryCode`
-                            );
+                <PopoverTrigger asChild>
+                  <FormControl>
+                    <Button
+                      ref={countryTriggerRef}
+                      variant='outline'
+                      className={cn(
+                        'rounded-md shadow-none justify-between px-3 font-normal hover:bg-muted bg-card active:ring h-12',
+                        !field.value && 'text-muted-foreground'
+                      )}
+                      hasError={!!fieldState.error}
+                      disabled={isConfirmingCheckout}
+                      aria-required={
+                        requiredFields?.[`${sectionKey}CountryCode`]
+                      }
+                      tabIndex={0}
+                    >
+                      {field.value
+                        ? countries.find(
+                            country => country.value === field.value
+                          )?.label
+                        : t.shipping.selectCountry}
+                      <ChevronsUpDown className='opacity-50' />
+                    </Button>
+                  </FormControl>
+                </PopoverTrigger>
+                <PopoverContent
+                  className='p-0 rounded-md'
+                  style={{
+                    width: triggerWidth ? `${triggerWidth + 2}px` : '100%',
+                  }}
+                >
+                  <Command>
+                    <CommandInput
+                      placeholder={t.shipping.searchCountry}
+                      className='h-12'
+                      disabled={isConfirmingCheckout}
+                    />
+                    <CommandList>
+                      <CommandEmpty>{t.shipping.noCountryFound}</CommandEmpty>
+                      <CommandGroup>
+                        {countries.map(country => (
+                          <CommandItem
+                            value={country.label}
+                            key={country.value}
+                            onSelect={() => {
+                              // Get current country before setting the new one
+                              const previousCountry = form.getValues(
+                                `${sectionKey}CountryCode`
+                              );
 
-                            // Set the new country value
-                            form.setValue(
-                              `${sectionKey}CountryCode`,
-                              country.value,
-                              {
-                                shouldValidate: true,
+                              // Set the new country value
+                              form.setValue(
+                                `${sectionKey}CountryCode`,
+                                country.value,
+                                {
+                                  shouldValidate: true,
+                                }
+                              );
+
+                              if (previousCountry !== country.value) {
+                                form.setValue(`${sectionKey}AddressLine1`, '', {
+                                  shouldDirty: true,
+                                  shouldValidate: false,
+                                });
+                                form.setValue(`${sectionKey}AdminArea1`, '', {
+                                  shouldDirty: true,
+                                  shouldValidate: false,
+                                });
+                                form.setValue(`${sectionKey}AdminArea2`, '', {
+                                  shouldDirty: true,
+                                  shouldValidate: false,
+                                });
+                                form.setValue(`${sectionKey}PostalCode`, '', {
+                                  shouldDirty: true,
+                                  shouldValidate: false,
+                                });
                               }
-                            );
 
-                            if (previousCountry !== country.value) {
-                              form.setValue(`${sectionKey}AddressLine1`, '', {
-                                shouldDirty: true,
-                                shouldValidate: false,
+                              // Track country selection event
+                              track({
+                                eventId: eventIds.changeCountry,
+                                type: TrackingEventType.CLICK,
+                                properties: {
+                                  sectionKey,
+                                  countryCode: country.value,
+                                  countryName: country.label,
+                                },
                               });
-                              form.setValue(`${sectionKey}AdminArea1`, '', {
-                                shouldDirty: true,
-                                shouldValidate: false,
-                              });
-                              form.setValue(`${sectionKey}AdminArea2`, '', {
-                                shouldDirty: true,
-                                shouldValidate: false,
-                              });
-                              form.setValue(`${sectionKey}PostalCode`, '', {
-                                shouldDirty: true,
-                                shouldValidate: false,
-                              });
-                            }
 
-                            // Track country selection event
-                            track({
-                              eventId: eventIds.changeCountry,
-                              type: TrackingEventType.CLICK,
-                              properties: {
-                                sectionKey,
-                                countryCode: country.value,
-                                countryName: country.label,
-                              },
-                            });
-
-                            setCountrySelectOpen(false);
-                          }}
-                          disabled={isConfirmingCheckout}
-                        >
-                          {country.label}
-                          <Check
-                            className={cn(
-                              'ml-auto',
-                              country.value === field.value
-                                ? 'opacity-100'
-                                : 'opacity-0'
-                            )}
-                          />
-                        </CommandItem>
-                      ))}
-                    </CommandGroup>
-                  </CommandList>
-                </Command>
-              </PopoverContent>
-            </Popover>
-            <FormMessage />
-          </FormItem>
-        )}
-      />
+                              setCountrySelectOpen(false);
+                            }}
+                            disabled={isConfirmingCheckout}
+                          >
+                            {country.label}
+                            <Check
+                              className={cn(
+                                'ml-auto',
+                                country.value === field.value
+                                  ? 'opacity-100'
+                                  : 'opacity-0'
+                              )}
+                            />
+                          </CommandItem>
+                        ))}
+                      </CommandGroup>
+                    </CommandList>
+                  </Command>
+                </PopoverContent>
+              </Popover>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      )}
 
       <div className='grid grid-cols-1 sm:grid-cols-2 gap-2'>
         <FormField
@@ -431,7 +442,8 @@ export function AddressForm({ sectionKey }: { sectionKey: string }) {
           render={({ field, fieldState }) => (
             <FormItem className='space-y-1'>
               <FormLabel className='sr-only'>
-                {t.shipping.firstName} ({t.general.optional})
+                {t.shipping.firstName}{' '}
+                {!onlyNames && `(${t.general.optional})`}
               </FormLabel>
               <FormControl>
                 <Input
@@ -467,188 +479,203 @@ export function AddressForm({ sectionKey }: { sectionKey: string }) {
         />
       </div>
 
-      <FormField
-        control={form.control}
-        name={`${sectionKey}AddressLine1`}
-        render={({ field, fieldState }) => (
-          <FormItem>
-            <FormLabel className='sr-only'>{t.shipping.address1}</FormLabel>
-            <FormControl>
-              {countryValue === 'US' && session?.enableAddressAutocomplete ? (
-                <AutoComplete
-                  data={addressMatchesQuery.data || []}
-                  value={field.value}
-                  onChange={field.onChange}
-                  onSelect={selectedAddress => {
-                    handleUpdateAddress(selectedAddress as Address);
-                  }}
-                  onOpenChange={setIsAutocompleteOpen}
-                  isLoading={
-                    addressMatchesQuery?.isLoading ||
-                    addressMatchesQuery?.isFetching
-                  }
-                  hasError={!!fieldState.error}
-                  aria-required={requiredFields?.[`${sectionKey}AddressLine1`]}
-                  disabled={isConfirmingCheckout}
-                />
-              ) : (
-                <Input
-                  placeholder={t.shipping.address1}
-                  hasError={!!fieldState.error}
-                  aria-required={requiredFields?.[`${sectionKey}AddressLine1`]}
-                  {...field}
-                  disabled={isConfirmingCheckout}
-                  autoComplete='off'
-                />
-              )}
-            </FormControl>
-            <FormMessage />
-          </FormItem>
-        )}
-      />
+      {!onlyNames && (
+        <>
+          <FormField
+            control={form.control}
+            name={`${sectionKey}AddressLine1`}
+            render={({ field, fieldState }) => (
+              <FormItem>
+                <FormLabel className='sr-only'>{t.shipping.address1}</FormLabel>
+                <FormControl>
+                  {countryValue === 'US' &&
+                  session?.enableAddressAutocomplete ? (
+                    <AutoComplete
+                      data={addressMatchesQuery.data || []}
+                      value={field.value}
+                      onChange={field.onChange}
+                      onSelect={selectedAddress => {
+                        handleUpdateAddress(selectedAddress as Address);
+                      }}
+                      onOpenChange={setIsAutocompleteOpen}
+                      isLoading={
+                        addressMatchesQuery?.isLoading ||
+                        addressMatchesQuery?.isFetching
+                      }
+                      hasError={!!fieldState.error}
+                      aria-required={
+                        requiredFields?.[`${sectionKey}AddressLine1`]
+                      }
+                      disabled={isConfirmingCheckout}
+                    />
+                  ) : (
+                    <Input
+                      placeholder={t.shipping.address1}
+                      hasError={!!fieldState.error}
+                      aria-required={
+                        requiredFields?.[`${sectionKey}AddressLine1`]
+                      }
+                      {...field}
+                      disabled={isConfirmingCheckout}
+                      autoComplete='off'
+                    />
+                  )}
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
 
-      <FormField
-        control={form.control}
-        name={`${sectionKey}AddressLine2`}
-        render={({ field, fieldState }) => (
-          <FormItem className='space-y-1'>
-            <FormLabel className='sr-only'>{t.shipping.address2}</FormLabel>
-            <FormControl>
-              <Input
-                placeholder={t.shipping.address2}
-                hasError={!!fieldState.error}
-                aria-required={requiredFields?.[`${sectionKey}AddressLine2`]}
-                {...field}
-                disabled={isConfirmingCheckout}
-                autoComplete='off'
-              />
-            </FormControl>
-            <FormMessage />
-          </FormItem>
-        )}
-      />
-
-      <div className='grid grid-cols-1 sm:grid-cols-3 gap-1'>
-        <FormField
-          control={form.control}
-          name={`${sectionKey}AdminArea2`}
-          render={({ field, fieldState }) => (
-            <FormItem className='space-y-1'>
-              <FormLabel className='sr-only'>{t.shipping.city}</FormLabel>
-              <FormControl>
-                <Input
-                  placeholder={t.shipping.city}
-                  hasError={!!fieldState.error}
-                  aria-required={requiredFields?.[`${sectionKey}AdminArea2`]}
-                  {...field}
-                  disabled={isConfirmingCheckout}
-                  autoComplete='off'
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-        <FormField
-          control={form.control}
-          name={`${sectionKey}AdminArea1`}
-          render={({ field, fieldState }) => (
-            <FormItem className='space-y-1'>
-              <FormLabel className='sr-only'>{t.shipping.region}</FormLabel>
-              <FormControl>
-                {hasRegionData(countryValue) ? (
-                  <Select
-                    value={field.value}
-                    onValueChange={value => {
-                      field.onChange(value);
-                      form.setValue(`${sectionKey}AdminArea1`, value, {
-                        shouldValidate: true,
-                      });
-
-                      form.setValue(`${sectionKey}PostalCode`, '', {
-                        shouldDirty: true,
-                        shouldValidate: false,
-                      });
-
-                      // Track region selection event
-                      track({
-                        eventId: eventIds.changeRegion,
-                        type: TrackingEventType.CLICK,
-                        properties: {
-                          sectionKey,
-                          countryCode: countryValue,
-                          regionCode: value,
-                          regionName: getRegions(countryValue)?.find(
-                            r => r.code === value
-                          )?.label,
-                        },
-                      });
-                    }}
-                    disabled={isConfirmingCheckout}
-                  >
-                    <FormControl>
-                      <SelectTrigger
-                        hasError={!!fieldState.error}
-                        disabled={isConfirmingCheckout}
-                        aria-required={
-                          requiredFields?.[`${sectionKey}AdminArea1`]
-                        }
-                        tabIndex={0}
-                      >
-                        <SelectValue placeholder={t.shipping.region} />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      {getRegions(countryValue)?.map(region => (
-                        <SelectItem
-                          key={region.code}
-                          value={region.code}
-                          disabled={isConfirmingCheckout}
-                        >
-                          {region.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                ) : (
+          <FormField
+            control={form.control}
+            name={`${sectionKey}AddressLine2`}
+            render={({ field, fieldState }) => (
+              <FormItem className='space-y-1'>
+                <FormLabel className='sr-only'>{t.shipping.address2}</FormLabel>
+                <FormControl>
                   <Input
-                    placeholder={t.shipping.region}
-                    {...field}
+                    placeholder={t.shipping.address2}
                     hasError={!!fieldState.error}
-                    aria-required={requiredFields?.[`${sectionKey}AdminArea1`]}
+                    aria-required={requiredFields?.[`${sectionKey}AddressLine2`]}
+                    {...field}
                     disabled={isConfirmingCheckout}
                     autoComplete='off'
                   />
-                )}
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
 
-        <FormField
-          control={form.control}
-          name={`${sectionKey}PostalCode`}
-          render={({ field, fieldState }) => (
-            <FormItem className='space-y-1'>
-              <FormLabel className='sr-only'>{t.shipping.postalCode}</FormLabel>
-              <FormControl>
-                <Input
-                  placeholder={t.shipping.postalCode}
-                  hasError={!!fieldState.error}
-                  aria-required={requiredFields?.[`${sectionKey}PostalCode`]}
-                  {...field}
-                  disabled={isConfirmingCheckout}
-                  autoComplete='off'
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-      </div>
+          <div className='grid grid-cols-1 sm:grid-cols-3 gap-1'>
+            <FormField
+              control={form.control}
+              name={`${sectionKey}AdminArea2`}
+              render={({ field, fieldState }) => (
+                <FormItem className='space-y-1'>
+                  <FormLabel className='sr-only'>{t.shipping.city}</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder={t.shipping.city}
+                      hasError={!!fieldState.error}
+                      aria-required={requiredFields?.[`${sectionKey}AdminArea2`]}
+                      {...field}
+                      disabled={isConfirmingCheckout}
+                      autoComplete='off'
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name={`${sectionKey}AdminArea1`}
+              render={({ field, fieldState }) => (
+                <FormItem className='space-y-1'>
+                  <FormLabel className='sr-only'>{t.shipping.region}</FormLabel>
+                  <FormControl>
+                    {hasRegionData(countryValue) ? (
+                      <Select
+                        value={field.value}
+                        onValueChange={value => {
+                          field.onChange(value);
+                          form.setValue(`${sectionKey}AdminArea1`, value, {
+                            shouldValidate: true,
+                          });
 
-      <PhoneInput sectionKey={sectionKey} disabled={isConfirmingCheckout} />
+                          form.setValue(`${sectionKey}PostalCode`, '', {
+                            shouldDirty: true,
+                            shouldValidate: false,
+                          });
+
+                          // Track region selection event
+                          track({
+                            eventId: eventIds.changeRegion,
+                            type: TrackingEventType.CLICK,
+                            properties: {
+                              sectionKey,
+                              countryCode: countryValue,
+                              regionCode: value,
+                              regionName: getRegions(countryValue)?.find(
+                                r => r.code === value
+                              )?.label,
+                            },
+                          });
+                        }}
+                        disabled={isConfirmingCheckout}
+                      >
+                        <FormControl>
+                          <SelectTrigger
+                            hasError={!!fieldState.error}
+                            disabled={isConfirmingCheckout}
+                            aria-required={
+                              requiredFields?.[`${sectionKey}AdminArea1`]
+                            }
+                            tabIndex={0}
+                          >
+                            <SelectValue placeholder={t.shipping.region} />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {getRegions(countryValue)?.map(region => (
+                            <SelectItem
+                              key={region.code}
+                              value={region.code}
+                              disabled={isConfirmingCheckout}
+                            >
+                              {region.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    ) : (
+                      <Input
+                        placeholder={t.shipping.region}
+                        {...field}
+                        hasError={!!fieldState.error}
+                        aria-required={
+                          requiredFields?.[`${sectionKey}AdminArea1`]
+                        }
+                        disabled={isConfirmingCheckout}
+                        autoComplete='off'
+                      />
+                    )}
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name={`${sectionKey}PostalCode`}
+              render={({ field, fieldState }) => (
+                <FormItem className='space-y-1'>
+                  <FormLabel className='sr-only'>
+                    {t.shipping.postalCode}
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder={t.shipping.postalCode}
+                      hasError={!!fieldState.error}
+                      aria-required={
+                        requiredFields?.[`${sectionKey}PostalCode`]
+                      }
+                      {...field}
+                      disabled={isConfirmingCheckout}
+                      autoComplete='off'
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+
+          <PhoneInput sectionKey={sectionKey} disabled={isConfirmingCheckout} />
+        </>
+      )}
     </fieldset>
   );
 }

--- a/packages/react/src/components/checkout/checkout.tsx
+++ b/packages/react/src/components/checkout/checkout.tsx
@@ -13,7 +13,7 @@ import { type Theme, useTheme } from '@/hooks/use-theme';
 import { useVariables } from '@/hooks/use-variables';
 import type { TrackingProperties } from '@/tracking/event-properties';
 import { TrackingProvider } from '@/tracking/tracking-provider';
-import type { CheckoutSession } from '@/types';
+import { PaymentMethodType, type CheckoutSession } from '@/types';
 import { CheckoutFormContainer } from './form/checkout-form-container';
 import type { Target } from './target/target';
 
@@ -280,38 +280,61 @@ export function Checkout(props: CheckoutProps) {
       }
 
       // Billing address validation - only required if not using shipping address OR pickup
-      const requireBillingAddress =
-        !data.paymentUseShippingAddress ||
-        data.deliveryMethod === DeliveryMethods.PICKUP;
+      // BUT skip for free orders (paymentMethod === 'offline')
+      const isFreeOrder = data.paymentMethod === PaymentMethodType.OFFLINE;
+      const isPickup = data.deliveryMethod === DeliveryMethods.PICKUP;
+      const isFreePickup = isFreeOrder && isPickup;
 
-      if (requireBillingAddress) {
-        // Basic billing fields required for all countries
-        const billingFields = [
+      // For free pickup orders, only require first/last name (no address)
+      if (isFreePickup) {
+        const nameFields = [
           { key: 'billingFirstName', message: t.validation.enterFirstName },
           { key: 'billingLastName', message: t.validation.enterLastName },
-          { key: 'billingAddressLine1', message: t.validation.enterAddress },
-          { key: 'billingAdminArea2', message: t.validation.enterCity },
-          {
-            key: 'billingPostalCode',
-            message: t.validation.enterZipPostalCode,
-          },
-          { key: 'billingCountryCode', message: t.validation.enterCountry },
         ];
 
-        if (hasRegionData(String(data.billingCountryCode))) {
-          billingFields.push({
-            key: 'billingAdminArea1',
-            message: t.validation.selectState,
-          });
-        }
-
-        for (const { key, message } of billingFields) {
+        for (const { key, message } of nameFields) {
           if (!data[key as keyof typeof data]) {
             ctx.addIssue({
               code: z.ZodIssueCode.custom,
               message,
               path: [key],
             });
+          }
+        }
+      } else {
+        // Full billing address validation - required if not using shipping address OR pickup
+        const requireBillingAddress =
+          !data.paymentUseShippingAddress || isPickup;
+
+        if (requireBillingAddress) {
+          // Basic billing fields required for all countries
+          const billingFields = [
+            { key: 'billingFirstName', message: t.validation.enterFirstName },
+            { key: 'billingLastName', message: t.validation.enterLastName },
+            { key: 'billingAddressLine1', message: t.validation.enterAddress },
+            { key: 'billingAdminArea2', message: t.validation.enterCity },
+            {
+              key: 'billingPostalCode',
+              message: t.validation.enterZipPostalCode,
+            },
+            { key: 'billingCountryCode', message: t.validation.enterCountry },
+          ];
+
+          if (hasRegionData(String(data.billingCountryCode))) {
+            billingFields.push({
+              key: 'billingAdminArea1',
+              message: t.validation.selectState,
+            });
+          }
+
+          for (const { key, message } of billingFields) {
+            if (!data[key as keyof typeof data]) {
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message,
+                path: [key],
+              });
+            }
           }
         }
       }

--- a/packages/react/src/components/checkout/form/custom-form-provider.tsx
+++ b/packages/react/src/components/checkout/form/custom-form-provider.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import type { FieldPath, UseFormReturn, UseFormTrigger } from 'react-hook-form';
 import { FormProvider } from 'react-hook-form';
+import { PaymentMethodType } from '@/types';
 import type { CheckoutFormData } from '../checkout';
 import { DeliveryMethods } from '../delivery/delivery-method';
 
@@ -50,18 +51,28 @@ export function CustomFormProvider<
         else {
           const values = currentMethods.getValues();
           const deliveryMethod = values.deliveryMethod as unknown as string;
+          const paymentMethod = values.paymentMethod as unknown as string;
           const paymentUseShippingAddress =
             values.paymentUseShippingAddress as unknown as boolean;
           const isPickup = deliveryMethod === DeliveryMethods.PICKUP;
           const isShipping = deliveryMethod === DeliveryMethods.SHIP;
-          const requireBillingAddress = !paymentUseShippingAddress || isPickup;
+          const isFreeOrder = paymentMethod === PaymentMethodType.OFFLINE;
+          const isFreePickup = isFreeOrder && isPickup;
 
           // Get all field names and filter based on conditions
           const allFieldNames = Object.keys(values);
           let fieldNames = [...allFieldNames] as Array<FieldPath<TFormValues>>;
 
-          /* If using shipping address for billing (and not pickup), filter out billing-related field validations */
-          if (!requireBillingAddress) {
+          /* For free pickup orders, only validate billingFirstName and billingLastName */
+          if (isFreePickup) {
+            fieldNames = fieldNames.filter(
+              fieldName =>
+                !fieldName.startsWith('billing') ||
+                fieldName === 'billingFirstName' ||
+                fieldName === 'billingLastName'
+            );
+          } else if (paymentUseShippingAddress && !isPickup) {
+            /* If using shipping address for billing (and not pickup), filter out billing-related field validations */
             fieldNames = fieldNames.filter(
               fieldName => !fieldName.startsWith('billing')
             );
@@ -76,7 +87,7 @@ export function CustomFormProvider<
 
           // Trigger validation only on the filtered fields if any condition is true,
           // otherwise trigger on all fields
-          if (paymentUseShippingAddress || isPickup) {
+          if (paymentUseShippingAddress || isPickup || isFreeOrder) {
             result = await methods.trigger(fieldNames, triggerOptions);
           } else {
             result = await methods.trigger(undefined, triggerOptions);

--- a/packages/react/src/components/checkout/payment/free-payment-form.test.ts
+++ b/packages/react/src/components/checkout/payment/free-payment-form.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Helper function to determine which billing fields are required
+ * based on payment method and delivery method.
+ *
+ * This mirrors the validation logic in checkout.tsx and custom-form-provider.tsx
+ */
+function getRequiredBillingFields(
+  paymentMethod: string,
+  deliveryMethod: string,
+  paymentUseShippingAddress: boolean
+): string[] {
+  const isFreeOrder = paymentMethod === 'offline';
+  const isPickup = deliveryMethod === 'PICKUP';
+  const isFreePickup = isFreeOrder && isPickup;
+
+  // For free pickup orders, only require name fields
+  if (isFreePickup) {
+    return ['billingFirstName', 'billingLastName'];
+  }
+
+  // For paid pickup or when not using shipping address, require full billing
+  const requireBillingAddress = !paymentUseShippingAddress || isPickup;
+
+  if (requireBillingAddress) {
+    return [
+      'billingFirstName',
+      'billingLastName',
+      'billingAddressLine1',
+      'billingAdminArea2',
+      'billingPostalCode',
+      'billingCountryCode',
+    ];
+  }
+
+  // When using shipping address for billing (non-pickup), no billing fields required
+  return [];
+}
+
+/**
+ * Helper function to filter billing field names for validation
+ * This mirrors the logic in custom-form-provider.tsx
+ */
+function filterBillingFieldsForValidation(
+  allFieldNames: string[],
+  paymentMethod: string,
+  deliveryMethod: string,
+  paymentUseShippingAddress: boolean
+): string[] {
+  const isFreeOrder = paymentMethod === 'offline';
+  const isPickup = deliveryMethod === 'PICKUP';
+  const isFreePickup = isFreeOrder && isPickup;
+
+  if (isFreePickup) {
+    // For free pickup, only include billingFirstName and billingLastName
+    return allFieldNames.filter(
+      fieldName =>
+        !fieldName.startsWith('billing') ||
+        fieldName === 'billingFirstName' ||
+        fieldName === 'billingLastName'
+    );
+  }
+
+  if (paymentUseShippingAddress && !isPickup) {
+    // Filter out all billing fields when using shipping address
+    return allFieldNames.filter(fieldName => !fieldName.startsWith('billing'));
+  }
+
+  // Return all fields for other cases
+  return allFieldNames;
+}
+
+describe('FreePaymentForm - Billing validation logic', () => {
+  describe('getRequiredBillingFields', () => {
+    it('should only require first and last name for free pickup orders', () => {
+      const result = getRequiredBillingFields('offline', 'PICKUP', true);
+
+      expect(result).toEqual(['billingFirstName', 'billingLastName']);
+      expect(result).not.toContain('billingAddressLine1');
+      expect(result).not.toContain('billingPostalCode');
+    });
+
+    it('should require full billing address for paid pickup orders', () => {
+      const result = getRequiredBillingFields('card', 'PICKUP', true);
+
+      expect(result).toContain('billingFirstName');
+      expect(result).toContain('billingLastName');
+      expect(result).toContain('billingAddressLine1');
+      expect(result).toContain('billingAdminArea2');
+      expect(result).toContain('billingPostalCode');
+      expect(result).toContain('billingCountryCode');
+    });
+
+    it('should require full billing when not using shipping address', () => {
+      const result = getRequiredBillingFields('card', 'SHIP', false);
+
+      expect(result).toContain('billingFirstName');
+      expect(result).toContain('billingAddressLine1');
+    });
+
+    it('should not require billing fields when using shipping address for shipping orders', () => {
+      const result = getRequiredBillingFields('card', 'SHIP', true);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should only require names for free orders with SHIP delivery using shipping address', () => {
+      // Free order with shipping that uses shipping address - no billing needed
+      const result = getRequiredBillingFields('offline', 'SHIP', true);
+
+      // For free non-pickup orders using shipping address, no billing required
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('filterBillingFieldsForValidation', () => {
+    const allFields = [
+      'contactEmail',
+      'deliveryMethod',
+      'billingFirstName',
+      'billingLastName',
+      'billingAddressLine1',
+      'billingAdminArea1',
+      'billingAdminArea2',
+      'billingPostalCode',
+      'billingCountryCode',
+      'shippingFirstName',
+      'shippingLastName',
+      'shippingAddressLine1',
+    ];
+
+    it('should filter billing fields to only names for free pickup', () => {
+      const result = filterBillingFieldsForValidation(
+        allFields,
+        'offline',
+        'PICKUP',
+        true
+      );
+
+      expect(result).toContain('contactEmail');
+      expect(result).toContain('billingFirstName');
+      expect(result).toContain('billingLastName');
+      expect(result).not.toContain('billingAddressLine1');
+      expect(result).not.toContain('billingPostalCode');
+    });
+
+    it('should keep all billing fields for paid pickup', () => {
+      const result = filterBillingFieldsForValidation(
+        allFields,
+        'card',
+        'PICKUP',
+        true
+      );
+
+      expect(result).toContain('billingFirstName');
+      expect(result).toContain('billingAddressLine1');
+      expect(result).toContain('billingPostalCode');
+    });
+
+    it('should filter out all billing fields when using shipping address for non-pickup', () => {
+      const result = filterBillingFieldsForValidation(
+        allFields,
+        'card',
+        'SHIP',
+        true
+      );
+
+      expect(result).toContain('contactEmail');
+      expect(result).toContain('shippingFirstName');
+      expect(result).not.toContain('billingFirstName');
+      expect(result).not.toContain('billingAddressLine1');
+    });
+
+    it('should keep all fields when not using shipping address', () => {
+      const result = filterBillingFieldsForValidation(
+        allFields,
+        'card',
+        'SHIP',
+        false
+      );
+
+      expect(result).toContain('billingFirstName');
+      expect(result).toContain('billingAddressLine1');
+      expect(result).toContain('shippingFirstName');
+    });
+  });
+});

--- a/packages/react/src/components/checkout/payment/free-payment-form.tsx
+++ b/packages/react/src/components/checkout/payment/free-payment-form.tsx
@@ -2,12 +2,21 @@ import { LoaderCircle } from 'lucide-react';
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
 import { useCheckoutContext } from '@/components/checkout/checkout';
+import { DeliveryMethods } from '@/components/checkout/delivery/delivery-method';
 import {
   PaymentProvider,
   useConfirmCheckout,
 } from '@/components/checkout/payment/utils/use-confirm-checkout';
 import { useIsPaymentDisabled } from '@/components/checkout/payment/utils/use-is-payment-disabled';
 import { Button } from '@/components/ui/button';
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
 import { useGoDaddyContext } from '@/godaddy-provider';
 import { GraphQLErrorWithCodes } from '@/lib/graphql-with-errors';
 import { cn } from '@/lib/utils';
@@ -19,6 +28,9 @@ export function FreePaymentForm() {
   const isPaymentDisabled = useIsPaymentDisabled();
   const form = useFormContext();
   const confirmCheckout = useConfirmCheckout();
+
+  const deliveryMethod = form.watch('deliveryMethod');
+  const isPickup = deliveryMethod === DeliveryMethods.PICKUP;
 
   const handleSubmit = React.useCallback(async () => {
     const valid = await form.trigger();
@@ -43,7 +55,7 @@ export function FreePaymentForm() {
     }
   }, [form, confirmCheckout.mutateAsync, setCheckoutErrors]);
 
-  return isConfirmingCheckout ? (
+  const submitButton = isConfirmingCheckout ? (
     <Button
       type='button'
       className='w-full flex items-center justify-center gap-2 px-8 h-10'
@@ -63,4 +75,51 @@ export function FreePaymentForm() {
       <span>{t.payment.freePayment}</span>
     </Button>
   );
+
+  // For pickup orders, show name fields
+  if (isPickup) {
+    return (
+      <div className='space-y-4'>
+        <div className='grid grid-cols-2 gap-4'>
+          <FormField
+            control={form.control}
+            name='billingFirstName'
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t.shipping.firstName}</FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder={t.shipping.firstName}
+                    {...field}
+                    disabled={isConfirmingCheckout}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name='billingLastName'
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t.shipping.lastName}</FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder={t.shipping.lastName}
+                    {...field}
+                    disabled={isConfirmingCheckout}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+        {submitButton}
+      </div>
+    );
+  }
+
+  return submitButton;
 }

--- a/packages/react/src/components/checkout/payment/free-payment-form.tsx
+++ b/packages/react/src/components/checkout/payment/free-payment-form.tsx
@@ -1,6 +1,7 @@
 import { LoaderCircle } from 'lucide-react';
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
+import { AddressForm } from '@/components/checkout/address/address-form';
 import { useCheckoutContext } from '@/components/checkout/checkout';
 import { DeliveryMethods } from '@/components/checkout/delivery/delivery-method';
 import {
@@ -9,14 +10,6 @@ import {
 } from '@/components/checkout/payment/utils/use-confirm-checkout';
 import { useIsPaymentDisabled } from '@/components/checkout/payment/utils/use-is-payment-disabled';
 import { Button } from '@/components/ui/button';
-import {
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from '@/components/ui/form';
-import { Input } from '@/components/ui/input';
 import { useGoDaddyContext } from '@/godaddy-provider';
 import { GraphQLErrorWithCodes } from '@/lib/graphql-with-errors';
 import { cn } from '@/lib/utils';
@@ -80,42 +73,7 @@ export function FreePaymentForm() {
   if (isPickup) {
     return (
       <div className='space-y-4'>
-        <div className='grid grid-cols-2 gap-4'>
-          <FormField
-            control={form.control}
-            name='billingFirstName'
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>{t.shipping.firstName}</FormLabel>
-                <FormControl>
-                  <Input
-                    placeholder={t.shipping.firstName}
-                    {...field}
-                    disabled={isConfirmingCheckout}
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-          <FormField
-            control={form.control}
-            name='billingLastName'
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>{t.shipping.lastName}</FormLabel>
-                <FormControl>
-                  <Input
-                    placeholder={t.shipping.lastName}
-                    {...field}
-                    disabled={isConfirmingCheckout}
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-        </div>
+        <AddressForm sectionKey='billing' onlyNames />
         {submitButton}
       </div>
     );


### PR DESCRIPTION
## Summary
Fixes the "Complete your free order" button not working for free pickup orders.

## Problem
When a customer had a free order with PICKUP delivery, clicking "Complete your free order" did nothing. The form validation required full billing address fields, but those fields weren't visible in the UI, causing silent validation failure.

## Solution
- For free pickup orders (`paymentMethod === 'offline'` + `deliveryMethod === 'PICKUP'`), only require `billingFirstName` and `billingLastName`
- Display name input fields in the payment section for this scenario
- Skip billing address validation (address, city, state, postal code) for free pickup orders

## Changes
- `checkout.tsx` - Updated Zod schema validation to handle free pickup case
- `custom-form-provider.tsx` - Updated field filtering logic for validation
- `free-payment-form.tsx` - Added name input fields for pickup orders
- `free-payment-form.test.ts` - Added unit tests for billing validation logic

## Testing
- [x] Unit tests pass (105 tests)
- [ ] Manual testing with free pickup order


free payment and pickup upder: 

<img width="659" height="866" alt="Screenshot 2026-05-08 at 16 09 28" src="https://github.com/user-attachments/assets/46fa334b-5361-46b3-a04a-222d7560159f" />

## Related
VNEXT-79361