### PR TITLE
fix: app-connect tanstack pass raw body through to verification

### DIFF
--- a/.changeset/upset-waves-rescue.md
+++ b/.changeset/upset-waves-rescue.md
@@ -1,0 +1,5 @@
+---
+"@godaddy/app-connect": patch
+---
+
+Verification middlewares for tanstack now pass raw text of request body through to verification function.

--- a/packages/app-connect/src/tanstack/index.test.ts
+++ b/packages/app-connect/src/tanstack/index.test.ts
@@ -1,0 +1,495 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Capture the server callback passed to createMiddleware().server()
+let capturedServerFn: (args: {
+  next: (opts?: unknown) => unknown;
+  request: Request;
+}) => Promise<unknown>;
+
+vi.mock('@tanstack/react-start', () => ({
+  createMiddleware: () => ({
+    server: (fn: typeof capturedServerFn) => {
+      capturedServerFn = fn;
+      return 'middleware-instance';
+    },
+  }),
+}));
+
+vi.mock('../utils/verification', () => ({
+  verifyAction: vi.fn(),
+}));
+
+vi.mock('../utils/webhook', () => ({
+  verifyWebhookSubscription: vi.fn(),
+}));
+
+import { verifyAction } from '../utils/verification';
+import { verifyWebhookSubscription } from '../utils/webhook';
+import { createActionMiddleware, createWebhookMiddleware } from './index';
+
+const mockVerifyAction = vi.mocked(verifyAction);
+const mockVerifyWebhookSubscription = vi.mocked(verifyWebhookSubscription);
+
+function createMockRequest(
+  body?: Record<string, unknown>,
+  headers?: Record<string, string>,
+): Request {
+  const requestInit: RequestInit = {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      ...(headers ?? {}),
+    },
+  };
+
+  if (body !== undefined) {
+    requestInit.body = JSON.stringify(body);
+  }
+
+  return new Request('https://example.com/api/test?foo=bar', requestInit);
+}
+
+function createInvalidJsonRequest(): Request {
+  return new Request('https://example.com/api/test', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: '{invalid json',
+  });
+}
+
+describe('createActionMiddleware', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should parse body and pass it in context on success', async () => {
+    const body = { action: 'test', data: { key: 'value' } };
+    const request = createMockRequest(body);
+    const next = vi.fn().mockResolvedValue('next-result');
+
+    mockVerifyAction.mockResolvedValue({ success: true });
+
+    createActionMiddleware();
+    const result = await capturedServerFn({ next, request });
+
+    expect(next).toHaveBeenCalledWith({ context: { body } });
+    expect(result).toBe('next-result');
+  });
+
+  it('should pass undefined body in context when request has no body', async () => {
+    const request = createMockRequest();
+    const next = vi.fn().mockResolvedValue('next-result');
+
+    mockVerifyAction.mockResolvedValue({ success: true });
+
+    createActionMiddleware();
+    await capturedServerFn({ next, request });
+
+    expect(next).toHaveBeenCalledWith({ context: { body: undefined } });
+  });
+
+  it('should read body as text from cloned request (not json)', async () => {
+    const body = { action: 'test' };
+    const request = createMockRequest(body);
+    const jsonSpy = vi.spyOn(request, 'json');
+    const textSpy = vi.spyOn(Request.prototype, 'text');
+    const next = vi.fn().mockResolvedValue('next-result');
+
+    mockVerifyAction.mockResolvedValue({ success: true });
+
+    createActionMiddleware();
+    await capturedServerFn({ next, request });
+
+    // Should read as text (from clone), not call json() on original
+    expect(jsonSpy).not.toHaveBeenCalled();
+    expect(textSpy).toHaveBeenCalledTimes(1);
+
+    textSpy.mockRestore();
+  });
+
+  it('should build a correct VerifiableRequest and pass it to verifyAction', async () => {
+    const body = { action: 'test' };
+    const request = createMockRequest(body, {
+      'x-store-id': 'store-123',
+    });
+    const next = vi.fn().mockResolvedValue('next-result');
+
+    mockVerifyAction.mockResolvedValue({ success: true });
+
+    const options = { maxTimestampAgeSeconds: 300 };
+    createActionMiddleware(options);
+    await capturedServerFn({ next, request });
+
+    // Verify that body is passed as RAW STRING (not parsed object) for signature verification
+    expect(mockVerifyAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'POST',
+        url: 'https://example.com/api/test?foo=bar',
+        path: '/api/test',
+        body: JSON.stringify(body), // Raw string, not parsed object
+        headers: expect.objectContaining({
+          'content-type': 'application/json',
+          'x-store-id': 'store-123',
+        }),
+        query: { foo: 'bar' },
+      }),
+      options,
+    );
+  });
+
+  it('should throw a 401 Response when verification fails', async () => {
+    const errorPayload = {
+      name: 'MISSING_HEADER',
+      message: 'Missing required header',
+    };
+    const body = { action: 'test' };
+    const request = createMockRequest(body);
+    const next = vi.fn();
+
+    mockVerifyAction.mockResolvedValue({ success: false, error: errorPayload });
+
+    createActionMiddleware();
+
+    try {
+      await capturedServerFn({ next, request });
+      expect.unreachable('Should have thrown');
+    } catch (thrown) {
+      expect(thrown).toBeInstanceOf(Response);
+      const response = thrown as Response;
+      expect(response.status).toBe(401);
+      expect(response.headers.get('Content-Type')).toBe('application/json');
+      const responseBody = await response.json();
+      expect(responseBody).toEqual(errorPayload);
+    }
+
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should not call next when verification fails', async () => {
+    const body = { action: 'test' };
+    const request = createMockRequest(body);
+    const next = vi.fn();
+
+    mockVerifyAction.mockResolvedValue({
+      success: false,
+      error: { name: 'ERROR', message: 'fail' },
+    });
+
+    createActionMiddleware();
+
+    try {
+      await capturedServerFn({ next, request });
+    } catch {
+      // expected
+    }
+
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should throw a 400 Response with InvalidBodyError when body is invalid JSON', async () => {
+    const request = createInvalidJsonRequest();
+    const next = vi.fn();
+
+    createActionMiddleware();
+
+    try {
+      await capturedServerFn({ next, request });
+      expect.unreachable('Should have thrown');
+    } catch (thrown) {
+      expect(thrown).toBeInstanceOf(Response);
+      const response = thrown as Response;
+      expect(response.status).toBe(400);
+      expect(response.headers.get('Content-Type')).toBe('application/json');
+      const responseBody = await response.json();
+      expect(responseBody.name).toBe('INVALID_REQUEST_BODY');
+      expect(responseBody.message).toBe(
+        'The request body contains invalid JSON',
+      );
+      expect(responseBody.correlationId).toBeDefined();
+      expect(responseBody.details).toEqual([
+        {
+          issue: 'INVALID_JSON',
+          description: 'The request body could not be parsed as JSON',
+          location: 'body',
+        },
+      ]);
+    }
+
+    expect(next).not.toHaveBeenCalled();
+    expect(mockVerifyAction).not.toHaveBeenCalled();
+  });
+
+  it('should preserve exact raw body string including whitespace', async () => {
+    // Test that formatting/whitespace is preserved exactly
+    const rawBodyString = '{\n  "action": "test",\n  "data": {\n    "key": "value"\n  }\n}';
+    const request = new Request('https://example.com/api/test', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: rawBodyString,
+    });
+    const next = vi.fn().mockResolvedValue('next-result');
+
+    mockVerifyAction.mockResolvedValue({ success: true });
+
+    createActionMiddleware();
+    await capturedServerFn({ next, request });
+
+    // Verify raw string is passed exactly as-is to verification
+    expect(mockVerifyAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: rawBodyString, // Exact match including whitespace
+      }),
+      undefined,
+    );
+
+    // But parsed body (without whitespace) is passed to next
+    expect(next).toHaveBeenCalledWith({
+      context: {
+        body: { action: 'test', data: { key: 'value' } },
+      },
+    });
+  });
+
+  it('should preserve unicode and special characters in raw body', async () => {
+    const rawBodyString = '{"emoji":"🎉","unicode":"\\u00e9","text":"café"}';
+    const request = new Request('https://example.com/api/test', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: rawBodyString,
+    });
+    const next = vi.fn().mockResolvedValue('next-result');
+
+    mockVerifyAction.mockResolvedValue({ success: true });
+
+    createActionMiddleware();
+    await capturedServerFn({ next, request });
+
+    // Verify exact raw string preservation
+    expect(mockVerifyAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: rawBodyString,
+      }),
+      undefined,
+    );
+  });
+});
+
+describe('createWebhookMiddleware', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should parse body and pass it in context on success', async () => {
+    const body = { event: 'order.created', payload: { id: '123' } };
+    const request = createMockRequest(body);
+    const next = vi.fn().mockResolvedValue('next-result');
+
+    mockVerifyWebhookSubscription.mockReturnValue({ success: true });
+
+    createWebhookMiddleware();
+    const result = await capturedServerFn({ next, request });
+
+    expect(next).toHaveBeenCalledWith({ context: { body } });
+    expect(result).toBe('next-result');
+  });
+
+  it('should pass undefined body in context when request has no body', async () => {
+    const request = createMockRequest();
+    const next = vi.fn().mockResolvedValue('next-result');
+
+    mockVerifyWebhookSubscription.mockReturnValue({ success: true });
+
+    createWebhookMiddleware();
+    await capturedServerFn({ next, request });
+
+    expect(next).toHaveBeenCalledWith({ context: { body: undefined } });
+  });
+
+  it('should read body as text from cloned request (not json)', async () => {
+    const body = { event: 'order.created' };
+    const request = createMockRequest(body);
+    const jsonSpy = vi.spyOn(request, 'json');
+    const textSpy = vi.spyOn(Request.prototype, 'text');
+    const next = vi.fn().mockResolvedValue('next-result');
+
+    mockVerifyWebhookSubscription.mockReturnValue({ success: true });
+
+    createWebhookMiddleware();
+    await capturedServerFn({ next, request });
+
+    // Should read as text (from clone), not call json() on original
+    expect(jsonSpy).not.toHaveBeenCalled();
+    expect(textSpy).toHaveBeenCalledTimes(1);
+
+    textSpy.mockRestore();
+  });
+
+  it('should build a correct VerifiableRequest and pass it to verifyWebhookSubscription', async () => {
+    const body = { event: 'order.created' };
+    const request = createMockRequest(body, {
+      'webhook-signature': 'sig-value',
+    });
+    const next = vi.fn().mockResolvedValue('next-result');
+
+    mockVerifyWebhookSubscription.mockReturnValue({ success: true });
+
+    const options = { secret: 'test-secret' };
+    createWebhookMiddleware(options);
+    await capturedServerFn({ next, request });
+
+    // Verify that body is passed as RAW STRING (not parsed object) for signature verification
+    expect(mockVerifyWebhookSubscription).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'POST',
+        url: 'https://example.com/api/test?foo=bar',
+        path: '/api/test',
+        body: JSON.stringify(body), // Raw string, not parsed object
+        headers: expect.objectContaining({
+          'content-type': 'application/json',
+          'webhook-signature': 'sig-value',
+        }),
+        query: { foo: 'bar' },
+      }),
+      options,
+    );
+  });
+
+  it('should throw a 401 Response when verification fails', async () => {
+    const errorPayload = {
+      name: 'INVALID_WEBHOOK_SIGNATURE',
+      message: 'The webhook signature is invalid',
+    };
+    const body = { event: 'order.created' };
+    const request = createMockRequest(body);
+    const next = vi.fn();
+
+    mockVerifyWebhookSubscription.mockReturnValue({
+      success: false,
+      error: errorPayload,
+    });
+
+    createWebhookMiddleware();
+
+    try {
+      await capturedServerFn({ next, request });
+      expect.unreachable('Should have thrown');
+    } catch (thrown) {
+      expect(thrown).toBeInstanceOf(Response);
+      const response = thrown as Response;
+      expect(response.status).toBe(401);
+      expect(response.headers.get('Content-Type')).toBe('application/json');
+      const responseBody = await response.json();
+      expect(responseBody).toEqual(errorPayload);
+    }
+
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should not call next when verification fails', async () => {
+    const body = { event: 'order.created' };
+    const request = createMockRequest(body);
+    const next = vi.fn();
+
+    mockVerifyWebhookSubscription.mockReturnValue({
+      success: false,
+      error: { name: 'ERROR', message: 'fail' },
+    });
+
+    createWebhookMiddleware();
+
+    try {
+      await capturedServerFn({ next, request });
+    } catch {
+      // expected
+    }
+
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should throw a 400 Response with InvalidBodyError when body is invalid JSON', async () => {
+    const request = createInvalidJsonRequest();
+    const next = vi.fn();
+
+    createWebhookMiddleware();
+
+    try {
+      await capturedServerFn({ next, request });
+      expect.unreachable('Should have thrown');
+    } catch (thrown) {
+      expect(thrown).toBeInstanceOf(Response);
+      const response = thrown as Response;
+      expect(response.status).toBe(400);
+      expect(response.headers.get('Content-Type')).toBe('application/json');
+      const responseBody = await response.json();
+      expect(responseBody.name).toBe('INVALID_REQUEST_BODY');
+      expect(responseBody.message).toBe(
+        'The request body contains invalid JSON',
+      );
+      expect(responseBody.correlationId).toBeDefined();
+      expect(responseBody.details).toEqual([
+        {
+          issue: 'INVALID_JSON',
+          description: 'The request body could not be parsed as JSON',
+          location: 'body',
+        },
+      ]);
+    }
+
+    expect(next).not.toHaveBeenCalled();
+    expect(mockVerifyWebhookSubscription).not.toHaveBeenCalled();
+  });
+
+  it('should preserve exact raw body string including whitespace', async () => {
+    // Test that formatting/whitespace is preserved exactly
+    const rawBodyString = '{\n  "event": "order.created",\n  "payload": {\n    "id": "123"\n  }\n}';
+    const request = new Request('https://example.com/api/test', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: rawBodyString,
+    });
+    const next = vi.fn().mockResolvedValue('next-result');
+
+    mockVerifyWebhookSubscription.mockReturnValue({ success: true });
+
+    createWebhookMiddleware();
+    await capturedServerFn({ next, request });
+
+    // Verify raw string is passed exactly as-is to verification
+    expect(mockVerifyWebhookSubscription).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: rawBodyString, // Exact match including whitespace
+      }),
+      undefined,
+    );
+
+    // But parsed body (without whitespace) is passed to next
+    expect(next).toHaveBeenCalledWith({
+      context: {
+        body: { event: 'order.created', payload: { id: '123' } },
+      },
+    });
+  });
+
+  it('should preserve unicode and special characters in raw body', async () => {
+    const rawBodyString = '{"event":"user.created","data":"café","emoji":"🎉"}';
+    const request = new Request('https://example.com/api/test', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: rawBodyString,
+    });
+    const next = vi.fn().mockResolvedValue('next-result');
+
+    mockVerifyWebhookSubscription.mockReturnValue({ success: true });
+
+    createWebhookMiddleware();
+    await capturedServerFn({ next, request });
+
+    // Verify exact raw string preservation
+    expect(mockVerifyWebhookSubscription).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: rawBodyString,
+      }),
+      undefined,
+    );
+  });
+});

--- a/packages/app-connect/src/tanstack/index.test.ts
+++ b/packages/app-connect/src/tanstack/index.test.ts
@@ -49,20 +49,12 @@ function createMockRequest(
   return new Request('https://example.com/api/test?foo=bar', requestInit);
 }
 
-function createInvalidJsonRequest(): Request {
-  return new Request('https://example.com/api/test', {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: '{invalid json',
-  });
-}
-
 describe('createActionMiddleware', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('should parse body and pass it in context on success', async () => {
+  it('should call next without arguments on success', async () => {
     const body = { action: 'test', data: { key: 'value' } };
     const request = createMockRequest(body);
     const next = vi.fn().mockResolvedValue('next-result');
@@ -72,20 +64,8 @@ describe('createActionMiddleware', () => {
     createActionMiddleware();
     const result = await capturedServerFn({ next, request });
 
-    expect(next).toHaveBeenCalledWith({ context: { body } });
+    expect(next).toHaveBeenCalledWith();
     expect(result).toBe('next-result');
-  });
-
-  it('should pass undefined body in context when request has no body', async () => {
-    const request = createMockRequest();
-    const next = vi.fn().mockResolvedValue('next-result');
-
-    mockVerifyAction.mockResolvedValue({ success: true });
-
-    createActionMiddleware();
-    await capturedServerFn({ next, request });
-
-    expect(next).toHaveBeenCalledWith({ context: { body: undefined } });
   });
 
   it('should read body as text from cloned request (not json)', async () => {
@@ -186,39 +166,6 @@ describe('createActionMiddleware', () => {
     expect(next).not.toHaveBeenCalled();
   });
 
-  it('should throw a 400 Response with InvalidBodyError when body is invalid JSON', async () => {
-    const request = createInvalidJsonRequest();
-    const next = vi.fn();
-
-    createActionMiddleware();
-
-    try {
-      await capturedServerFn({ next, request });
-      expect.unreachable('Should have thrown');
-    } catch (thrown) {
-      expect(thrown).toBeInstanceOf(Response);
-      const response = thrown as Response;
-      expect(response.status).toBe(400);
-      expect(response.headers.get('Content-Type')).toBe('application/json');
-      const responseBody = await response.json();
-      expect(responseBody.name).toBe('INVALID_REQUEST_BODY');
-      expect(responseBody.message).toBe(
-        'The request body contains invalid JSON',
-      );
-      expect(responseBody.correlationId).toBeDefined();
-      expect(responseBody.details).toEqual([
-        {
-          issue: 'INVALID_JSON',
-          description: 'The request body could not be parsed as JSON',
-          location: 'body',
-        },
-      ]);
-    }
-
-    expect(next).not.toHaveBeenCalled();
-    expect(mockVerifyAction).not.toHaveBeenCalled();
-  });
-
   it('should preserve exact raw body string including whitespace', async () => {
     // Test that formatting/whitespace is preserved exactly
     const rawBodyString = '{\n  "action": "test",\n  "data": {\n    "key": "value"\n  }\n}';
@@ -241,13 +188,6 @@ describe('createActionMiddleware', () => {
       }),
       undefined,
     );
-
-    // But parsed body (without whitespace) is passed to next
-    expect(next).toHaveBeenCalledWith({
-      context: {
-        body: { action: 'test', data: { key: 'value' } },
-      },
-    });
   });
 
   it('should preserve unicode and special characters in raw body', async () => {
@@ -279,7 +219,7 @@ describe('createWebhookMiddleware', () => {
     vi.clearAllMocks();
   });
 
-  it('should parse body and pass it in context on success', async () => {
+  it('should call next without arguments on success', async () => {
     const body = { event: 'order.created', payload: { id: '123' } };
     const request = createMockRequest(body);
     const next = vi.fn().mockResolvedValue('next-result');
@@ -289,20 +229,8 @@ describe('createWebhookMiddleware', () => {
     createWebhookMiddleware();
     const result = await capturedServerFn({ next, request });
 
-    expect(next).toHaveBeenCalledWith({ context: { body } });
+    expect(next).toHaveBeenCalledWith();
     expect(result).toBe('next-result');
-  });
-
-  it('should pass undefined body in context when request has no body', async () => {
-    const request = createMockRequest();
-    const next = vi.fn().mockResolvedValue('next-result');
-
-    mockVerifyWebhookSubscription.mockReturnValue({ success: true });
-
-    createWebhookMiddleware();
-    await capturedServerFn({ next, request });
-
-    expect(next).toHaveBeenCalledWith({ context: { body: undefined } });
   });
 
   it('should read body as text from cloned request (not json)', async () => {
@@ -406,39 +334,6 @@ describe('createWebhookMiddleware', () => {
     expect(next).not.toHaveBeenCalled();
   });
 
-  it('should throw a 400 Response with InvalidBodyError when body is invalid JSON', async () => {
-    const request = createInvalidJsonRequest();
-    const next = vi.fn();
-
-    createWebhookMiddleware();
-
-    try {
-      await capturedServerFn({ next, request });
-      expect.unreachable('Should have thrown');
-    } catch (thrown) {
-      expect(thrown).toBeInstanceOf(Response);
-      const response = thrown as Response;
-      expect(response.status).toBe(400);
-      expect(response.headers.get('Content-Type')).toBe('application/json');
-      const responseBody = await response.json();
-      expect(responseBody.name).toBe('INVALID_REQUEST_BODY');
-      expect(responseBody.message).toBe(
-        'The request body contains invalid JSON',
-      );
-      expect(responseBody.correlationId).toBeDefined();
-      expect(responseBody.details).toEqual([
-        {
-          issue: 'INVALID_JSON',
-          description: 'The request body could not be parsed as JSON',
-          location: 'body',
-        },
-      ]);
-    }
-
-    expect(next).not.toHaveBeenCalled();
-    expect(mockVerifyWebhookSubscription).not.toHaveBeenCalled();
-  });
-
   it('should preserve exact raw body string including whitespace', async () => {
     // Test that formatting/whitespace is preserved exactly
     const rawBodyString = '{\n  "event": "order.created",\n  "payload": {\n    "id": "123"\n  }\n}';
@@ -461,13 +356,6 @@ describe('createWebhookMiddleware', () => {
       }),
       undefined,
     );
-
-    // But parsed body (without whitespace) is passed to next
-    expect(next).toHaveBeenCalledWith({
-      context: {
-        body: { event: 'order.created', payload: { id: '123' } },
-      },
-    });
   });
 
   it('should preserve unicode and special characters in raw body', async () => {

--- a/packages/app-connect/src/tanstack/index.ts
+++ b/packages/app-connect/src/tanstack/index.ts
@@ -15,6 +15,16 @@ export function createActionMiddleware(options?: VerificationOptions) {
     async ({ next, request }) => {
       const url = new URL(request.url);
 
+      // Read raw body as text from cloned request
+      // This preserves the original request stream for downstream handlers
+      let rawBody: string | undefined;
+
+      if (request.body) {
+        // Clone the request to read body without consuming original
+        const clonedRequest = request.clone();
+        rawBody = await clonedRequest.text();
+      }
+
       const verifiableRequest: VerifiableRequest = {
         method: request.method,
         url: request.url,
@@ -22,7 +32,8 @@ export function createActionMiddleware(options?: VerificationOptions) {
         query: Object.fromEntries(url.searchParams),
         // biome-ignore lint/suspicious/noExplicitAny: Headers type compatibility issue
         headers: Object.fromEntries(request.headers as any),
-        body: request.body ? await request.json() : undefined,
+        // Pass raw body string directly for signature verification
+        body: rawBody,
       };
 
       const result = await verifyAction(verifiableRequest, options);
@@ -34,6 +45,7 @@ export function createActionMiddleware(options?: VerificationOptions) {
         });
       }
 
+      // Original request is passed to next(), allowing downstream to call .json()
       return next();
     },
   );
@@ -50,6 +62,16 @@ export function createWebhookMiddleware(options?: WebhookVerificationOptions) {
     async ({ next, request }) => {
       const url = new URL(request.url);
 
+      // Read raw body as text from cloned request
+      // This preserves the original request stream for downstream handlers
+      let rawBody: string | undefined;
+
+      if (request.body) {
+        // Clone the request to read body without consuming original
+        const clonedRequest = request.clone();
+        rawBody = await clonedRequest.text();
+      }
+
       const verifiableRequest: VerifiableRequest = {
         method: request.method,
         url: request.url,
@@ -57,7 +79,8 @@ export function createWebhookMiddleware(options?: WebhookVerificationOptions) {
         query: Object.fromEntries(url.searchParams),
         // biome-ignore lint/suspicious/noExplicitAny: Headers type compatibility issue
         headers: Object.fromEntries(request.headers as any),
-        body: request.body ? await request.json() : undefined,
+        // Pass raw body string directly for signature verification
+        body: rawBody,
       };
 
       const result = verifyWebhookSubscription(verifiableRequest, options);
@@ -69,6 +92,7 @@ export function createWebhookMiddleware(options?: WebhookVerificationOptions) {
         });
       }
 
+      // Original request is passed to next(), allowing downstream to call .json()
       return next();
     },
   );

--- a/packages/app-connect/src/tanstack/index.ts
+++ b/packages/app-connect/src/tanstack/index.ts
@@ -8,6 +8,30 @@ import { verifyAction } from '../utils/verification';
 import { verifyWebhookSubscription } from '../utils/webhook';
 
 /**
+ * Creates a 400 Response for invalid JSON in request body
+ */
+function createInvalidJsonResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      name: 'INVALID_REQUEST_BODY',
+      message: 'The request body contains invalid JSON',
+      correlationId: crypto.randomUUID(),
+      details: [
+        {
+          issue: 'INVALID_JSON',
+          description: 'The request body could not be parsed as JSON',
+          location: 'body',
+        },
+      ],
+    }),
+    {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    },
+  );
+}
+
+/**
  * Creates a middleware for TanStack Start that verifies signed action requests
  */
 export function createActionMiddleware(options?: VerificationOptions) {
@@ -18,11 +42,22 @@ export function createActionMiddleware(options?: VerificationOptions) {
       // Read raw body as text from cloned request
       // This preserves the original request stream for downstream handlers
       let rawBody: string | undefined;
+      let parsedBody: unknown;
 
       if (request.body) {
         // Clone the request to read body without consuming original
         const clonedRequest = request.clone();
         rawBody = await clonedRequest.text();
+
+        // Parse the raw body for downstream use
+        if (rawBody) {
+          try {
+            parsedBody = JSON.parse(rawBody);
+          } catch (error) {
+            // Return 400 for invalid JSON
+            throw createInvalidJsonResponse();
+          }
+        }
       }
 
       const verifiableRequest: VerifiableRequest = {
@@ -45,8 +80,8 @@ export function createActionMiddleware(options?: VerificationOptions) {
         });
       }
 
-      // Original request is passed to next(), allowing downstream to call .json()
-      return next();
+      // Pass parsed body to next middleware via context
+      return next({ context: { body: parsedBody } });
     },
   );
 
@@ -65,11 +100,22 @@ export function createWebhookMiddleware(options?: WebhookVerificationOptions) {
       // Read raw body as text from cloned request
       // This preserves the original request stream for downstream handlers
       let rawBody: string | undefined;
+      let parsedBody: unknown;
 
       if (request.body) {
         // Clone the request to read body without consuming original
         const clonedRequest = request.clone();
         rawBody = await clonedRequest.text();
+
+        // Parse the raw body for downstream use
+        if (rawBody) {
+          try {
+            parsedBody = JSON.parse(rawBody);
+          } catch (error) {
+            // Return 400 for invalid JSON
+            throw createInvalidJsonResponse();
+          }
+        }
       }
 
       const verifiableRequest: VerifiableRequest = {
@@ -92,8 +138,8 @@ export function createWebhookMiddleware(options?: WebhookVerificationOptions) {
         });
       }
 
-      // Original request is passed to next(), allowing downstream to call .json()
-      return next();
+      // Pass parsed body to next middleware via context
+      return next({ context: { body: parsedBody } });
     },
   );
 

--- a/packages/app-connect/src/tanstack/index.ts
+++ b/packages/app-connect/src/tanstack/index.ts
@@ -8,30 +8,6 @@ import { verifyAction } from '../utils/verification';
 import { verifyWebhookSubscription } from '../utils/webhook';
 
 /**
- * Creates a 400 Response for invalid JSON in request body
- */
-function createInvalidJsonResponse(): Response {
-  return new Response(
-    JSON.stringify({
-      name: 'INVALID_REQUEST_BODY',
-      message: 'The request body contains invalid JSON',
-      correlationId: crypto.randomUUID(),
-      details: [
-        {
-          issue: 'INVALID_JSON',
-          description: 'The request body could not be parsed as JSON',
-          location: 'body',
-        },
-      ],
-    }),
-    {
-      status: 400,
-      headers: { 'Content-Type': 'application/json' },
-    },
-  );
-}
-
-/**
  * Creates a middleware for TanStack Start that verifies signed action requests
  */
 export function createActionMiddleware(options?: VerificationOptions) {
@@ -42,22 +18,11 @@ export function createActionMiddleware(options?: VerificationOptions) {
       // Read raw body as text from cloned request
       // This preserves the original request stream for downstream handlers
       let rawBody: string | undefined;
-      let parsedBody: unknown;
 
       if (request.body) {
         // Clone the request to read body without consuming original
         const clonedRequest = request.clone();
         rawBody = await clonedRequest.text();
-
-        // Parse the raw body for downstream use
-        if (rawBody) {
-          try {
-            parsedBody = JSON.parse(rawBody);
-          } catch (error) {
-            // Return 400 for invalid JSON
-            throw createInvalidJsonResponse();
-          }
-        }
       }
 
       const verifiableRequest: VerifiableRequest = {
@@ -80,8 +45,7 @@ export function createActionMiddleware(options?: VerificationOptions) {
         });
       }
 
-      // Pass parsed body to next middleware via context
-      return next({ context: { body: parsedBody } });
+      return next();
     },
   );
 
@@ -100,22 +64,11 @@ export function createWebhookMiddleware(options?: WebhookVerificationOptions) {
       // Read raw body as text from cloned request
       // This preserves the original request stream for downstream handlers
       let rawBody: string | undefined;
-      let parsedBody: unknown;
 
       if (request.body) {
         // Clone the request to read body without consuming original
         const clonedRequest = request.clone();
         rawBody = await clonedRequest.text();
-
-        // Parse the raw body for downstream use
-        if (rawBody) {
-          try {
-            parsedBody = JSON.parse(rawBody);
-          } catch (error) {
-            // Return 400 for invalid JSON
-            throw createInvalidJsonResponse();
-          }
-        }
       }
 
       const verifiableRequest: VerifiableRequest = {
@@ -138,8 +91,7 @@ export function createWebhookMiddleware(options?: WebhookVerificationOptions) {
         });
       }
 
-      // Pass parsed body to next middleware via context
-      return next({ context: { body: parsedBody } });
+      return next();
     },
   );
 

--- a/packages/app-connect/src/types/verifiable-request.ts
+++ b/packages/app-connect/src/types/verifiable-request.ts
@@ -18,6 +18,11 @@ export interface VerifiableRequest {
   /** The request headers as a record */
   headers: Record<string, string | string[] | undefined>;
 
-  /** The request body, if any */
+  /**
+   * The request body, if any.
+   * - For Express middleware: pre-parsed object from express.json()
+   * - For TanStack middleware: raw string from request.text()
+   * - For Next.js: caller-provided (typically pre-parsed with request.json())
+   */
   body?: unknown;
 }

--- a/packages/app-connect/src/utils/verification.ts
+++ b/packages/app-connect/src/utils/verification.ts
@@ -102,7 +102,10 @@ export function canonicalizeRequest(req: VerifiableRequest): string {
     canonicalString += '\n';
 
     // Add the body to the canonical string
-    // Use original body exactly as received to match Go middleware
+    // Use raw body string if available (TanStack), otherwise stringify parsed body (Express)
+    // IMPORTANT: For signature verification to work, we need the exact bytes that were signed.
+    // TanStack middleware provides the raw body string directly for accurate verification.
+    // Express middleware provides parsed object from express.json(), which we re-stringify.
     const bodyContent =
       typeof req.body === 'string' ? req.body : JSON.stringify(req.body);
     canonicalString += bodyContent;
@@ -450,7 +453,7 @@ export function verifyWebhookSubscription(
     }
 
     return ok();
-  } catch (err) {
+  } catch (_err) {
     return error(new InvalidWebhookSignatureError().toJSON());
   }
 }


### PR DESCRIPTION
## Summary

This PR fixes 2 related issues.

### Pass raw body through to verification
`JSON.stringify(req.body)` call in the verification module's `canonicalizeRequest` strips any pretty-printing or extraneous spaces in the body. That broke verification, which requires the exact same bytes from the body in the canonical string.

### Allow later middlewares to use parsed JSON request body

The verifyAction middleware from @godaddy/app-connect calls request.json() for signature verification but does not pass the parsed body forward through the middleware chain. Since a Fetch API Request body can only be consumed once, calling request.json() again throws a TypeError ("disturbed or locked").

See: https://developer.mozilla.org/en-US/docs/Web/API/Request/json#exceptions

## Changeset

<!--
Help reviewers and the release process by included a changeset entry.
Use `pnpm run changeset` and follow the prompts to create a changeset.
-->

- [x] Changeset added ([docs](https://github.com/godaddy/javascript#submit-a-changeset))

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
- [x] unit tests
