### PR TITLE
add additional targets

### DIFF
--- a/.changeset/green-monkeys-sell.md
+++ b/.changeset/green-monkeys-sell.md
@@ -1,0 +1,5 @@
+---
+"@godaddy/react": patch
+---
+
+Add additional targets

--- a/.changeset/green-monkeys-sell.md
+++ b/.changeset/green-monkeys-sell.md
@@ -1,5 +1,6 @@
 ---
 "@godaddy/react": patch
+"@godaddy/localizations": patch
 ---
 
-Add additional targets
+Add additional targets and extend billing flows with localization updates

--- a/packages/localizations/src/deDe.ts
+++ b/packages/localizations/src/deDe.ts
@@ -94,6 +94,10 @@ export const deDe = {
   payment: {
     title: 'Zahlung',
     description: 'Alle Zahlungen sind sicher und verschlüsselt.',
+    billingInformation: {
+      title: 'Rechnungsinformationen',
+      description: 'Geben Sie Ihre Rechnungsinformationen ein.',
+    },
     billingAddress: {
       title: 'Rechnungsadresse',
       description: 'Geben Sie Ihre Rechnungsadresse ein.',

--- a/packages/localizations/src/enAu.ts
+++ b/packages/localizations/src/enAu.ts
@@ -94,6 +94,10 @@ export const enAu = {
   payment: {
     title: 'Payment',
     description: 'All payments are secure and encrypted.',
+    billingInformation: {
+      title: 'Billing Information',
+      description: 'Enter your billing information.',
+    },
     billingAddress: {
       title: 'Billing Address',
       description: 'Enter your billing address.',

--- a/packages/localizations/src/enIe.ts
+++ b/packages/localizations/src/enIe.ts
@@ -94,6 +94,10 @@ export const enIe = {
   payment: {
     title: 'Payment',
     description: 'All payments are secure and encrypted.',
+    billingInformation: {
+      title: 'Billing Information',
+      description: 'Enter your billing information.',
+    },
     billingAddress: {
       title: 'Billing Address',
       description: 'Enter your billing address.',

--- a/packages/localizations/src/enUs.ts
+++ b/packages/localizations/src/enUs.ts
@@ -94,6 +94,10 @@ export const enUs = {
   payment: {
     title: 'Payment',
     description: 'All payments are secure and encrypted.',
+    billingInformation: {
+      title: 'Billing Information',
+      description: 'Enter your billing information.',
+    },
     billingAddress: {
       title: 'Billing Address',
       description: 'Enter your billing address.',

--- a/packages/localizations/src/esAr.ts
+++ b/packages/localizations/src/esAr.ts
@@ -94,6 +94,10 @@ export const esAr = {
   payment: {
     title: 'Pago',
     description: 'Todos los pagos son seguros y encriptados.',
+    billingInformation: {
+      title: 'Información de facturación',
+      description: 'Ingrese su información de facturación.',
+    },
     billingAddress: {
       title: 'Dirección de Facturación',
       description: 'Ingresá tu dirección de facturación.',

--- a/packages/localizations/src/esCl.ts
+++ b/packages/localizations/src/esCl.ts
@@ -94,6 +94,10 @@ export const esCl = {
   payment: {
     title: 'Pago',
     description: 'Todos los pagos son seguros y encriptados.',
+    billingInformation: {
+      title: 'Información de facturación',
+      description: 'Ingrese su información de facturación.',
+    },
     billingAddress: {
       title: 'Dirección de Facturación',
       description: 'Ingresa tu dirección de facturación.',

--- a/packages/localizations/src/esCo.ts
+++ b/packages/localizations/src/esCo.ts
@@ -94,6 +94,10 @@ export const esCo = {
   payment: {
     title: 'Pago',
     description: 'Todos los pagos son seguros y encriptados.',
+    billingInformation: {
+      title: 'Información de facturación',
+      description: 'Ingrese su información de facturación.',
+    },
     billingAddress: {
       title: 'Dirección de facturación',
       description: 'Ingresa tu dirección de facturación.',

--- a/packages/localizations/src/esEs.ts
+++ b/packages/localizations/src/esEs.ts
@@ -94,6 +94,10 @@ export const esEs = {
   payment: {
     title: 'Pago',
     description: 'Todos los pagos son seguros y están encriptados.',
+    billingInformation: {
+      title: 'Información de facturación',
+      description: 'Introduce tu información de facturación.',
+    },
     billingAddress: {
       title: 'Dirección de facturación',
       description: 'Introduce tu dirección de facturación.',

--- a/packages/localizations/src/esMx.ts
+++ b/packages/localizations/src/esMx.ts
@@ -94,6 +94,10 @@ export const esMx = {
   payment: {
     title: 'Pago',
     description: 'Todos los pagos son seguros y cifrados.',
+    billingInformation: {
+      title: 'Información de facturación',
+      description: 'Ingrese su información de facturación.',
+    },
     billingAddress: {
       title: 'Dirección de Facturación',
       description: 'Ingrese su dirección de facturación.',

--- a/packages/localizations/src/esPe.ts
+++ b/packages/localizations/src/esPe.ts
@@ -94,6 +94,10 @@ export const esPe = {
   payment: {
     title: 'Pago',
     description: 'Todos los pagos son seguros y encriptados.',
+    billingInformation: {
+      title: 'Información de facturación',
+      description: 'Ingrese su información de facturación.',
+    },
     billingAddress: {
       title: 'Dirección de Facturación',
       description: 'Ingrese su dirección de facturación.',

--- a/packages/localizations/src/esUs.ts
+++ b/packages/localizations/src/esUs.ts
@@ -94,6 +94,10 @@ export const esUs = {
   payment: {
     title: 'Pago',
     description: 'Todos los pagos son seguros y encriptados.',
+    billingInformation: {
+      title: 'Información de facturación',
+      description: 'Ingrese su información de facturación.',
+    },
     billingAddress: {
       title: 'Dirección de Facturación',
       description: 'Ingrese su dirección de facturación.',

--- a/packages/localizations/src/frCa.ts
+++ b/packages/localizations/src/frCa.ts
@@ -94,6 +94,10 @@ export const frCa = {
   payment: {
     title: 'Paiement',
     description: 'Tous les paiements sont sécurisés et chiffrés.',
+    billingInformation: {
+      title: 'Informations de facturation',
+      description: 'Saisissez vos informations de facturation.',
+    },
     billingAddress: {
       title: 'Adresse de facturation',
       description: 'Entrez votre adresse de facturation.',

--- a/packages/localizations/src/frFr.ts
+++ b/packages/localizations/src/frFr.ts
@@ -94,6 +94,10 @@ export const frFr = {
   payment: {
     title: 'Paiement',
     description: 'Tous les paiements sont sécurisés et chiffrés.',
+    billingInformation: {
+      title: 'Informations de facturation',
+      description: 'Saisissez vos informations de facturation.',
+    },
     billingAddress: {
       title: 'Adresse de facturation',
       description: 'Entrez votre adresse de facturation.',

--- a/packages/localizations/src/idId.ts
+++ b/packages/localizations/src/idId.ts
@@ -94,6 +94,10 @@ export const idId = {
   payment: {
     title: 'Pembayaran',
     description: 'Semua pembayaran aman dan terenkripsi.',
+    billingInformation: {
+      title: 'Informasi penagihan',
+      description: 'Masukkan informasi penagihan Anda.',
+    },
     billingAddress: {
       title: 'Alamat Penagihan',
       description: 'Masukkan alamat penagihan Anda.',

--- a/packages/localizations/src/itIt.ts
+++ b/packages/localizations/src/itIt.ts
@@ -94,6 +94,10 @@ export const itIt = {
   payment: {
     title: 'Pagamento',
     description: 'Tutti i pagamenti sono sicuri e crittografati.',
+    billingInformation: {
+      title: 'Informazioni di fatturazione',
+      description: 'Inserisci le informazioni di fatturazione.',
+    },
     billingAddress: {
       title: 'Indirizzo di Fatturazione',
       description: 'Inserisci il tuo indirizzo di fatturazione.',

--- a/packages/localizations/src/ptBr.ts
+++ b/packages/localizations/src/ptBr.ts
@@ -94,6 +94,10 @@ export const ptBr = {
   payment: {
     title: 'Pagamento',
     description: 'Todos os pagamentos são seguros e criptografados.',
+    billingInformation: {
+      title: 'Informações de cobrança',
+      description: 'Insira suas informações de cobrança.',
+    },
     billingAddress: {
       title: 'Endereço de Cobrança',
       description: 'Digite seu endereço de cobrança.',

--- a/packages/localizations/src/qaPs.ts
+++ b/packages/localizations/src/qaPs.ts
@@ -95,6 +95,10 @@ export const qaPs = {
   payment: {
     title: '[Þâÿmëñţ Îñförmâţîöñ]',
     description: '[Âll þâÿmëñţš ârë šëçürë ând ëñçrÿþţëd för ÿöür šâfëţÿ.]',
+    billingInformation: {
+      title: '[Bîllîñg Îñförmâţîöñ]',
+      description: '[Ëñţër ÿöür bîllîñg îñförmâţîöñ dëţâîlš.]',
+    },
     billingAddress: {
       title: '[Bîllîñg Âddrëšš Îñförmâţîöñ]',
       description: '[Ëñţër ÿöür bîllîñg âddrëšš dëţâîlš.]',

--- a/packages/localizations/src/trTr.ts
+++ b/packages/localizations/src/trTr.ts
@@ -94,6 +94,10 @@ export const trTr = {
   payment: {
     title: 'Ödeme',
     description: 'Tüm ödemeler güvenli ve şifrelidir.',
+    billingInformation: {
+      title: 'Fatura bilgileri',
+      description: 'Fatura bilgilerinizi girin.',
+    },
     billingAddress: {
       title: 'Fatura Adresi',
       description: 'Fatura adresinizi girin.',

--- a/packages/localizations/src/viVn.ts
+++ b/packages/localizations/src/viVn.ts
@@ -94,6 +94,10 @@ export const viVn = {
   payment: {
     title: 'Thanh toán',
     description: 'Tất cả thanh toán đều được bảo mật và mã hóa.',
+    billingInformation: {
+      title: 'Thông tin thanh toán',
+      description: 'Nhập thông tin thanh toán của bạn.',
+    },
     billingAddress: {
       title: 'Địa chỉ thanh toán',
       description: 'Nhập địa chỉ thanh toán của bạn.',

--- a/packages/localizations/src/zhCn.ts
+++ b/packages/localizations/src/zhCn.ts
@@ -90,6 +90,10 @@ export const zhCn = {
   payment: {
     title: '付款',
     description: '所有付款均经过安全加密。',
+    billingInformation: {
+      title: '账单信息',
+      description: '请输入您的账单信息。',
+    },
     billingAddress: {
       title: '账单地址',
       description: '请输入您的账单地址。',

--- a/packages/localizations/src/zhSg.ts
+++ b/packages/localizations/src/zhSg.ts
@@ -90,6 +90,10 @@ export const zhSg = {
   payment: {
     title: '付款',
     description: '所有付款都是安全且加密的。',
+    billingInformation: {
+      title: '账单信息',
+      description: '请输入您的账单信息。',
+    },
     billingAddress: {
       title: '账单地址',
       description: '输入您的账单地址。',

--- a/packages/react/src/components/checkout/checkout.tsx
+++ b/packages/react/src/components/checkout/checkout.tsx
@@ -13,7 +13,7 @@ import { type Theme, useTheme } from '@/hooks/use-theme';
 import { useVariables } from '@/hooks/use-variables';
 import type { TrackingProperties } from '@/tracking/event-properties';
 import { TrackingProvider } from '@/tracking/tracking-provider';
-import { PaymentMethodType, type CheckoutSession } from '@/types';
+import { type CheckoutSession, PaymentMethodType } from '@/types';
 import { CheckoutFormContainer } from './form/checkout-form-container';
 import type { Target } from './target/target';
 
@@ -258,6 +258,9 @@ export function Checkout(props: CheckoutProps) {
       ? baseCheckoutSchema.extend(checkoutFormSchema)
       : baseCheckoutSchema;
 
+    const enableBillingAddressCollection =
+      session?.enableBillingAddressCollection !== false;
+
     return extendedSchema.superRefine((data, ctx) => {
       if (data.billingPhone) {
         if (!checkIsValidPhone(String(data?.billingPhone))) {
@@ -285,8 +288,12 @@ export function Checkout(props: CheckoutProps) {
       const isPickup = data.deliveryMethod === DeliveryMethods.PICKUP;
       const isFreePickup = isFreeOrder && isPickup;
 
-      // For free pickup orders, only require first/last name (no address)
-      if (isFreePickup) {
+      const requireBillingNamesOnly =
+        (!enableBillingAddressCollection &&
+          (!data.paymentUseShippingAddress || isPickup)) ||
+        isFreePickup;
+
+      if (requireBillingNamesOnly) {
         const nameFields = [
           { key: 'billingFirstName', message: t.validation.enterFirstName },
           { key: 'billingLastName', message: t.validation.enterLastName },
@@ -301,40 +308,41 @@ export function Checkout(props: CheckoutProps) {
             });
           }
         }
-      } else {
-        // Full billing address validation - required if not using shipping address OR pickup
-        const requireBillingAddress =
-          !data.paymentUseShippingAddress || isPickup;
+      }
 
-        if (requireBillingAddress) {
-          // Basic billing fields required for all countries
-          const billingFields = [
-            { key: 'billingFirstName', message: t.validation.enterFirstName },
-            { key: 'billingLastName', message: t.validation.enterLastName },
-            { key: 'billingAddressLine1', message: t.validation.enterAddress },
-            { key: 'billingAdminArea2', message: t.validation.enterCity },
-            {
-              key: 'billingPostalCode',
-              message: t.validation.enterZipPostalCode,
-            },
-            { key: 'billingCountryCode', message: t.validation.enterCountry },
-          ];
+      const requireBillingAddress =
+        enableBillingAddressCollection &&
+        !isFreePickup &&
+        (!data.paymentUseShippingAddress || isPickup);
 
-          if (hasRegionData(String(data.billingCountryCode))) {
-            billingFields.push({
-              key: 'billingAdminArea1',
-              message: t.validation.selectState,
+      if (requireBillingAddress) {
+        // Basic billing fields required for all countries
+        const billingFields = [
+          { key: 'billingFirstName', message: t.validation.enterFirstName },
+          { key: 'billingLastName', message: t.validation.enterLastName },
+          { key: 'billingAddressLine1', message: t.validation.enterAddress },
+          { key: 'billingAdminArea2', message: t.validation.enterCity },
+          {
+            key: 'billingPostalCode',
+            message: t.validation.enterZipPostalCode,
+          },
+          { key: 'billingCountryCode', message: t.validation.enterCountry },
+        ];
+
+        if (hasRegionData(String(data.billingCountryCode))) {
+          billingFields.push({
+            key: 'billingAdminArea1',
+            message: t.validation.selectState,
+          });
+        }
+
+        for (const { key, message } of billingFields) {
+          if (!data[key as keyof typeof data]) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message,
+              path: [key],
             });
-          }
-
-          for (const { key, message } of billingFields) {
-            if (!data[key as keyof typeof data]) {
-              ctx.addIssue({
-                code: z.ZodIssueCode.custom,
-                message,
-                path: [key],
-              });
-            }
           }
         }
       }
@@ -375,7 +383,7 @@ export function Checkout(props: CheckoutProps) {
         }
       }
     });
-  }, [checkoutFormSchema, t]);
+  }, [checkoutFormSchema, session?.enableBillingAddressCollection, t]);
 
   const requiredFields = React.useMemo(() => {
     return getRequiredFieldsFromSchema(formSchema);

--- a/packages/react/src/components/checkout/line-items/line-items.tsx
+++ b/packages/react/src/components/checkout/line-items/line-items.tsx
@@ -135,23 +135,26 @@ export function DraftOrderLineItems({
                   ) : null}
                 </span>
                 <span className='text-xs text-muted-foreground'>
-                  {t.general.quantity}: {item.quantity} &middot;{' '}
+                  {t.general.quantity}: {item.quantity}
                   {onRemoveFromCart ? (
-                    <Button
-                      className='text-xs p-0 h-auto text-inherit underline'
-                      variant='link'
-                      onClick={() =>
-                        item.id ? onRemoveFromCart(item.id) : null
-                      }
-                      disabled={isRemovingFromCart}
-                      aria-label='Remove item'
-                    >
-                      {isRemovingFromCart && removingItemId === item.id ? (
-                        <span>{t.storefront.removing}</span>
-                      ) : (
-                        <span>{t.storefront.remove}</span>
-                      )}
-                    </Button>
+                    <>
+                      &middot;{' '}
+                      <Button
+                        className='text-xs p-0 h-auto text-inherit underline'
+                        variant='link'
+                        onClick={() =>
+                          item.id ? onRemoveFromCart(item.id) : null
+                        }
+                        disabled={isRemovingFromCart}
+                        aria-label='Remove item'
+                      >
+                        {isRemovingFromCart && removingItemId === item.id ? (
+                          <span>{t.storefront.removing}</span>
+                        ) : (
+                          <span>{t.storefront.remove}</span>
+                        )}
+                      </Button>
+                    </>
                   ) : null}
                 </span>
               </div>

--- a/packages/react/src/components/checkout/line-items/line-items.tsx
+++ b/packages/react/src/components/checkout/line-items/line-items.tsx
@@ -1,6 +1,7 @@
 // import { Badge } from "@/components/ui/badge";
 
 import { Image } from 'lucide-react';
+import { Target } from '@/components/checkout/target/target';
 import { useFormatCurrency } from '@/components/checkout/utils/format-currency';
 import { Button } from '@/components/ui/button.tsx';
 import { useGoDaddyContext } from '@/godaddy-provider';
@@ -76,6 +77,7 @@ export function DraftOrderLineItems({
 
   return (
     <div className='space-y-4 mb-4'>
+      <Target id='checkout.summary.line-items.before' />
       {items.map(item => (
         <div key={item.id} className='flex items-start space-x-4'>
           {item.image ? (
@@ -170,6 +172,7 @@ export function DraftOrderLineItems({
           </div>
         </div>
       ))}
+      <Target id='checkout.summary.line-items.after' />
     </div>
   );
 }

--- a/packages/react/src/components/checkout/payment/payment-form.tsx
+++ b/packages/react/src/components/checkout/payment/payment-form.tsx
@@ -252,10 +252,21 @@ export function PaymentForm(
     });
   }, [session, pazeSupported, applePaySupported, googlePaySupported]);
 
+  const shouldShowBillingNamesOnly =
+    paymentMethod !== PaymentMethodType.CREDIT_CARD &&
+    session?.enableBillingAddressCollection === false &&
+    !useShippingAddress;
+
   const isBillingAddressRequired =
-    session?.enableBillingAddressCollection &&
-    (!useShippingAddress || isPickup) &&
-    paymentMethod !== PaymentMethodType.CREDIT_CARD;
+    shouldShowBillingNamesOnly ||
+    (session?.enableBillingAddressCollection &&
+      (!useShippingAddress || isPickup) &&
+      paymentMethod !== PaymentMethodType.CREDIT_CARD);
+
+  const billingCopy =
+    shouldShowBillingNamesOnly && t.payment.billingInformation
+      ? t.payment.billingInformation
+      : t.payment.billingAddress;
 
   const filteredPaymentMethods = React.useMemo(() => {
     const sortedKeys = Object.keys(PAYMENT_METHOD_ICONS)
@@ -476,10 +487,13 @@ export function PaymentForm(
       {isBillingAddressRequired ? (
         <CheckoutSection className={isPickup ? 'pt-5' : ''}>
           <CheckoutSectionHeader
-            title={t.payment.billingAddress.title}
-            description={t.payment.billingAddress.description}
+            title={billingCopy.title}
+            description={billingCopy.description}
           />
-          <AddressForm sectionKey='billing' />
+          <AddressForm
+            sectionKey='billing'
+            onlyNames={shouldShowBillingNamesOnly}
+          />
         </CheckoutSection>
       ) : null}
 

--- a/packages/react/src/components/checkout/payment/payment-methods/credit-card/container.tsx
+++ b/packages/react/src/components/checkout/payment/payment-methods/credit-card/container.tsx
@@ -19,11 +19,22 @@ export function CreditCardContainer({ children }: { children?: ReactNode }) {
   const deliveryMethod = form.watch('deliveryMethod');
   const isShipping = deliveryMethod === DeliveryMethods.SHIP;
   const isPickup = deliveryMethod === DeliveryMethods.PICKUP;
+  const shouldShowBillingNamesOnly =
+    paymentMethod === PaymentMethodType.CREDIT_CARD &&
+    session?.enableBillingAddressCollection === false &&
+    !useShippingAddress;
+
   const isBillingAddressRequired =
     !session?.enableShipping ||
+    shouldShowBillingNamesOnly ||
     (session?.enableBillingAddressCollection &&
       (!useShippingAddress || isPickup) &&
       paymentMethod === PaymentMethodType.CREDIT_CARD);
+
+  const billingCopy =
+    shouldShowBillingNamesOnly && t.payment.billingInformation
+      ? t.payment.billingInformation
+      : t.payment.billingAddress;
 
   const getPaymentMethodDescription = useCallback((): string | undefined => {
     if (paymentMethod === 'card') {
@@ -42,17 +53,19 @@ export function CreditCardContainer({ children }: { children?: ReactNode }) {
       {children}
       {session?.enableShipping &&
         isShipping &&
-        paymentMethod === PaymentMethodType.CREDIT_CARD &&
-        session?.enableBillingAddressCollection && (
+        paymentMethod === PaymentMethodType.CREDIT_CARD && (
           <PaymentAddressToggle className='pt-4' />
         )}
       {isBillingAddressRequired ? (
         <CheckoutSection className='pt-5'>
           <CheckoutSectionHeader
-            title={t.payment.billingAddress.title}
-            description={t.payment.billingAddress.description}
+            title={billingCopy.title}
+            description={billingCopy.description}
           />
-          <AddressForm sectionKey='billing' />
+          <AddressForm
+            sectionKey='billing'
+            onlyNames={shouldShowBillingNamesOnly}
+          />
         </CheckoutSection>
       ) : null}
     </>

--- a/packages/react/src/components/checkout/target/target.tsx
+++ b/packages/react/src/components/checkout/target/target.tsx
@@ -27,6 +27,16 @@ export type Target =
   | 'checkout.form.submit.before'
   | 'checkout.form.submit.after'
   | 'checkout.summary.before'
+  | 'checkout.summary.line-items.before'
+  | 'checkout.summary.line-items.after'
+  | 'checkout.summary.totals.subtotal.before'
+  | 'checkout.summary.totals.discount.before'
+  | 'checkout.summary.totals.shipping.before'
+  | 'checkout.summary.totals.tip.before'
+  | 'checkout.summary.totals.taxes.before'
+  | 'checkout.summary.totals.total-due.before'
+  | 'checkout.summary.totals.total-due.after'
+  | 'checkout.summary.totals.after'
   | 'checkout.summary.after';
 
 export function Target({ id }: { id: Target }) {
@@ -35,9 +45,13 @@ export function Target({ id }: { id: Target }) {
 
   const target = targets?.[id];
 
+  if (!target && !debug) {
+    return null;
+  }
+
   let content: React.ReactNode = null;
   if (target) {
-    content = target?.(session);
+    content = target(session);
   } else if (debug) {
     content = <span className='text-xs text-blue-500'>{id}</span>;
   }

--- a/packages/react/src/components/checkout/totals/totals.tsx
+++ b/packages/react/src/components/checkout/totals/totals.tsx
@@ -1,4 +1,5 @@
 import { DiscountStandalone } from '@/components/checkout/discount/discount-standalone';
+import { Target } from '@/components/checkout/target/target';
 import { TotalLineItemSkeleton } from '@/components/checkout/totals/totals-skeleton';
 import { useFormatCurrency } from '@/components/checkout/utils/format-currency';
 import { useGoDaddyContext } from '@/godaddy-provider';
@@ -22,19 +23,21 @@ export interface DraftOrderTotalsProps {
   inputInMinorUnits?: boolean;
 }
 
-function TotalLineItem({
-  title,
-  description,
-  value,
-  currencyCode = 'USD',
-  inputInMinorUnits = false,
-}: {
+export interface TotalLineItemProps {
   title: string;
   description?: string;
   value: number;
   currencyCode?: string;
   inputInMinorUnits?: boolean;
-}) {
+}
+
+export function TotalLineItem({
+  title,
+  description,
+  value,
+  currencyCode = 'USD',
+  inputInMinorUnits = false,
+}: TotalLineItemProps) {
   const formatCurrency = useFormatCurrency();
 
   return (
@@ -82,6 +85,7 @@ export function DraftOrderTotals({
   return (
     <div className='grid gap-4'>
       <div className='space-y-2'>
+        <Target id='checkout.summary.totals.subtotal.before' />
         <TotalLineItem
           currencyCode={currencyCode}
           title={t.totals.subtotal}
@@ -93,6 +97,7 @@ export function DraftOrderTotals({
           value={subtotal}
           inputInMinorUnits={inputInMinorUnits}
         />
+        <Target id='checkout.summary.totals.discount.before' />
         {discount > 0 ? (
           isDiscountLoading ? (
             <TotalLineItemSkeleton title={t.totals.discount} />
@@ -105,6 +110,7 @@ export function DraftOrderTotals({
             />
           )
         ) : null}
+        <Target id='checkout.summary.totals.shipping.before' />
         {enableShipping &&
           (isShippingLoading ? (
             <TotalLineItemSkeleton title={t.totals.shipping} />
@@ -116,6 +122,7 @@ export function DraftOrderTotals({
               inputInMinorUnits={inputInMinorUnits}
             />
           ))}
+        <Target id='checkout.summary.totals.tip.before' />
         {tip ? (
           <TotalLineItem
             currencyCode={currencyCode}
@@ -124,6 +131,7 @@ export function DraftOrderTotals({
             inputInMinorUnits={inputInMinorUnits}
           />
         ) : null}
+        <Target id='checkout.summary.totals.taxes.before' />
         {enableTaxes &&
           (isTaxLoading ? (
             <TotalLineItemSkeleton title={t.totals.estimatedTaxes} />
@@ -135,6 +143,7 @@ export function DraftOrderTotals({
               inputInMinorUnits={inputInMinorUnits}
             />
           ))}
+        <Target id='checkout.summary.totals.after' />
       </div>
 
       {enableDiscounts ? (
@@ -149,6 +158,7 @@ export function DraftOrderTotals({
         </div>
       ) : null}
 
+      <Target id='checkout.summary.totals.total-due.before' />
       <div className='border-t border-border pt-4'>
         <div className='flex justify-between items-end'>
           <span className='text-sm'>{t.totals.totalDue}</span>
@@ -166,6 +176,7 @@ export function DraftOrderTotals({
           </div>
         </div>
       </div>
+      <Target id='checkout.summary.totals.total-due.after' />
     </div>
   );
 }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -14,6 +14,8 @@ export { useIsPaymentDisabled } from './components/checkout/payment/utils/use-is
 export {
   DraftOrderTotals,
   type DraftOrderTotalsProps,
+  TotalLineItem,
+  type TotalLineItemProps,
 } from './components/checkout/totals/totals';
 export * from './components/storefront';
 export * from './godaddy-provider';


### PR DESCRIPTION

## Summary

-  add granular checkout summary targets so integrators can inject custom line items and totals (before each block, including Total Due)                                                                   
 - expose the reusable TotalLineItem API, and streamline the Target component so it skips empty wrappers when no content is provided                                                                       
 - align billing flows when enableBillingAddressCollection is false: show the billing toggle, fall back to names-only forms, and surface new “Billing Information” copy (with translations) whenever only  
 name fields are collected                                                                                                                                                                                 
                            

## Changeset

<!--
Help reviewers and the release process by included a changeset entry.
Use `pnpm run changeset` and follow the prompts to create a changeset.
-->

- [X] Changeset added ([docs](https://github.com/godaddy/javascript#submit-a-changeset))

## Test Plan

If `enableBillingAddressCollection: true`

<img width="1142" height="1374" alt="CleanShot 2026-05-20 at 17 23 38@2x" src="https://github.com/user-attachments/assets/2d05d7f1-72ac-4ca2-9698-2872827ce6f3" />


If `enableBillingAddressCollection: false`

<img width="1164" height="828" alt="CleanShot 2026-05-20 at 17 24 26@2x" src="https://github.com/user-attachments/assets/45cdbb2a-9fac-410c-878e-a38f61fd901e" />


<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
