### PR TITLE
let checkout-api raise error on confirm for sync

### DIFF
--- a/.changeset/fix-missing-shipping-info-error.md
+++ b/.changeset/fix-missing-shipping-info-error.md
@@ -1,0 +1,5 @@
+---
+"@godaddy/react": patch
+---
+
+Return the missing shipping info error when checkout is blocked by absent shipping lines or fulfillment.

--- a/packages/react/src/components/checkout/payment/utils/use-confirm-checkout.ts
+++ b/packages/react/src/components/checkout/payment/utils/use-confirm-checkout.ts
@@ -103,8 +103,8 @@ export function useConfirmCheckout() {
         isShipping &&
         (!hasShippingLines || hasLineItemsMissingShippingFulfillment)
       ) {
-        setCheckoutErrors(['SHIPPING_METHOD_APPLICATION_FAILED']);
-        throw new Error('SHIPPING_METHOD_APPLICATION_FAILED');
+        setCheckoutErrors(['MISSING_SHIPPING_INFO']);
+        throw new Error('MISSING_SHIPPING_INFO');
       }
 
       const pickUpData = isPickup

--- a/packages/react/src/components/checkout/shipping/shipping-method.tsx
+++ b/packages/react/src/components/checkout/shipping/shipping-method.tsx
@@ -50,8 +50,7 @@ export function ShippingMethodForm() {
   const formatCurrency = useFormatCurrency();
   const form = useFormContext();
   const { t } = useGoDaddyContext();
-  const { session, isConfirmingCheckout, setCheckoutErrors } =
-    useCheckoutContext();
+  const { session, isConfirmingCheckout } = useCheckoutContext();
   const updateTaxes = useUpdateTaxes();
   const queryClient = useQueryClient();
   const isPaymentDisabled = useIsPaymentDisabled();
@@ -205,14 +204,6 @@ export function ShippingMethodForm() {
                 queryKey: ['draft-order', session.id],
               });
             },
-            onError: () => {
-              if (!isFulfillmentSync || !session?.id) return;
-
-              setCheckoutErrors(['SHIPPING_METHOD_APPLICATION_FAILED']);
-              queryClient.invalidateQueries({
-                queryKey: ['draft-order', session.id],
-              });
-            },
           });
         } else if (session?.enableTaxCollection) {
           updateTaxes.mutate(undefined);
@@ -239,7 +230,6 @@ export function ShippingMethodForm() {
     form,
     applyShippingMethod,
     updateTaxes.mutate,
-    setCheckoutErrors,
     session?.enableTaxCollection,
     queryClient,
     session?.id,


### PR DESCRIPTION
 Summary                                                                                                                                                                                                   
                                                                                                                                                                                                           
 Fixes the checkout error surfaced when a shipping order is blocked because shipping lines or line item fulfillment data are missing.                                                                      
                                                                                                                                                                                                           
 The fulfillment resync flow attempts to re-apply the selected shipping method when line items are still in NONE fulfillment mode. If checkout is still blocked, the user-facing error should be the       
 existing missing shipping info error (MISSING_SHIPPING_INFO / “Shipping address or method failed to apply”), rather than the more generic shipping method application error.                              
                                                                                                                                                                                                           
 This keeps the checkout-blocking validation aligned with the checkout-api confirm behavior and avoids surfacing the background resync mutation error directly to shoppers.                                
                                                                                                                                                                                                           
 Changeset                                                                                                                                                                                                 
                                                                                                                                                                                                           
 - [X] Changeset added (docs (https://github.com/godaddy/javascript#submit-a-changeset))                                                                                                                       
                                                                                                                                                                                                           
 Test Plan                                                                                                                                                                                                 
                                                                                                                                                                                                           
 - Verified the code path in useConfirmCheckout now returns MISSING_SHIPPING_INFO when shipping checkout is blocked by missing shipping lines or line items still missing shipping fulfillment.            
 - Verified the fulfillment resync mutation in shipping-method.tsx still invalidates the draft order on success so updated line item fulfillment state is refetched.                                       
 - Verified the resync mutation no longer sets a local SHIPPING_METHOD_APPLICATION_FAILED checkout error on failure; checkout confirmation remains responsible for surfacing the canonical missing         
 shipping info error.                                                                                                                                                                                      
 - Confirmed the related Playwright e2e expectations continue to use the existing “Shipping address or method failed to apply” message.                                                                    

