### PR TITLE
Vnext-81889 | | Name fields for in-person Pickup

### DIFF
--- a/.changeset/pickup-customer-names.md
+++ b/.changeset/pickup-customer-names.md
@@ -1,0 +1,5 @@
+---
+'@godaddy/react': patch
+---
+
+Require customer first and last name for in-person pickup orders. Names are collected in the Pickup section, synced to order billing, and validated for card, offline, free, and express checkout paths.

--- a/packages/react/src/components/checkout/__tests__/checkout-address.test.tsx
+++ b/packages/react/src/components/checkout/__tests__/checkout-address.test.tsx
@@ -312,8 +312,6 @@ describe('Checkout address behavior', () => {
         lastName: 'Buyer',
       },
     });
-    // Paid pickup collects a billing address in Payment; names-only sync must
-    // omit address so an existing billing.address is not cleared to null.
     expect(getLastUpdateInput()?.billing).not.toHaveProperty('address');
   });
 

--- a/packages/react/src/components/checkout/__tests__/checkout-address.test.tsx
+++ b/packages/react/src/components/checkout/__tests__/checkout-address.test.tsx
@@ -263,20 +263,20 @@ describe('Checkout address behavior', () => {
     });
   });
 
-  it('syncs only billing names in onlyNames mode without stale address fields', async () => {
+  it('syncs only billing names in onlyNames mode without clearing billing address', async () => {
     const draftOrder = buildDraftOrder({
       totals: {
-        subTotal: { value: 0, currencyCode: 'USD' },
+        subTotal: { value: 2500, currencyCode: 'USD' },
         discountTotal: { value: 0, currencyCode: 'USD' },
         shippingTotal: { value: 0, currencyCode: 'USD' },
         taxTotal: { value: 0, currencyCode: 'USD' },
         feeTotal: { value: 0, currencyCode: 'USD' },
-        total: { value: 0, currencyCode: 'USD' },
+        total: { value: 2500, currencyCode: 'USD' },
       },
       lineItems: [
         {
           fulfillmentMode: 'PICKUP',
-          unitAmount: { value: 0, currencyCode: 'USD' },
+          unitAmount: { value: 2500, currencyCode: 'USD' },
         },
       ],
       billing: {
@@ -284,7 +284,9 @@ describe('Checkout address behavior', () => {
         lastName: '',
         phone: '',
         email: 'jane@example.com',
-        address: buildBillingAddress({ addressLine1: 'Stale Billing St' }),
+        address: buildBillingAddress({
+          addressLine1: 'Paid Pickup Billing St',
+        }),
       },
     });
     const { user } = renderCheckout({
@@ -310,9 +312,9 @@ describe('Checkout address behavior', () => {
         lastName: 'Buyer',
       },
     });
-    expect(getLastUpdateInput()?.billing ?? {}).not.toMatchObject({
-      address: expect.objectContaining({ addressLine1: 'Stale Billing St' }),
-    });
+    // Paid pickup collects a billing address in Payment; names-only sync must
+    // omit address so an existing billing.address is not cleared to null.
+    expect(getLastUpdateInput()?.billing).not.toHaveProperty('address');
   });
 
   it('does not sync the address until country, state, city, and postal-code are valid', async () => {

--- a/packages/react/src/components/checkout/__tests__/checkout-draft-order-sync.test.tsx
+++ b/packages/react/src/components/checkout/__tests__/checkout-draft-order-sync.test.tsx
@@ -563,8 +563,9 @@ describe('Checkout draft-order field sync', () => {
     await waitForOperation('UpdateCheckoutSessionDraftOrder');
 
     expect(getLastUpdateInput()).toMatchObject({
-      billing: { firstName: 'Only', lastName: 'Names', address: null },
+      billing: { firstName: 'Only', lastName: 'Names' },
     });
+    expect(getLastUpdateInput()?.billing).not.toHaveProperty('address');
     expect(getLastUpdateInput()?.billing).not.toMatchObject({
       addressLine1: expect.anything(),
       postalCode: expect.anything(),

--- a/packages/react/src/components/checkout/__tests__/checkout-form-validation.test.tsx
+++ b/packages/react/src/components/checkout/__tests__/checkout-form-validation.test.tsx
@@ -2,7 +2,7 @@ import { enUs } from '@godaddy/localizations';
 import { screen, waitFor } from '@testing-library/react';
 import { useFormContext } from 'react-hook-form';
 import { describe, expect, it, vi } from 'vitest';
-import { PaymentMethodType, PaymentProvider } from '@/types';
+import { PaymentProvider } from '@/types';
 import {
   buildDraftOrder,
   buildLineItem,
@@ -42,7 +42,6 @@ function _offlinePaymentMethods() {
     mercadopago: null,
     ccavenue: null,
     offline: {
-      type: PaymentMethodType.OFFLINE,
       processor: PaymentProvider.OFFLINE,
       checkoutTypes: ['standard'],
     },
@@ -52,7 +51,6 @@ function _offlinePaymentMethods() {
 function stripeOnlyPaymentMethods() {
   return {
     card: {
-      type: PaymentMethodType.CREDIT_CARD,
       processor: PaymentProvider.STRIPE,
       checkoutTypes: ['standard'],
     },
@@ -179,7 +177,6 @@ describe('Checkout form validation', () => {
           ...stripeOnlyPaymentMethods(),
           card: null as never,
           offline: {
-            type: PaymentMethodType.OFFLINE,
             processor: PaymentProvider.OFFLINE,
             checkoutTypes: ['standard'],
           },

--- a/packages/react/src/components/checkout/__tests__/checkout-form-validation.test.tsx
+++ b/packages/react/src/components/checkout/__tests__/checkout-form-validation.test.tsx
@@ -163,6 +163,43 @@ describe('Checkout form validation', () => {
     expect(getOperations('ConfirmCheckoutSession')).toHaveLength(0);
   });
 
+  it('requires pickup customer names for paid pickup with offline payment', async () => {
+    const draftOrder = makePaidPickupOrder({
+      billing: {
+        firstName: '',
+        lastName: '',
+        address: buildShippingAddress({ addressLine1: '' }),
+      },
+    });
+    const { user } = renderCheckout({
+      draftOrder,
+      sessionOverrides: {
+        draftOrder,
+        paymentMethods: {
+          ...stripeOnlyPaymentMethods(),
+          card: null as never,
+          offline: {
+            type: PaymentMethodType.OFFLINE,
+            processor: PaymentProvider.OFFLINE,
+            checkoutTypes: ['standard'],
+          },
+        },
+        enableShipping: false,
+        enableLocalPickup: true,
+        enableTaxCollection: false,
+      },
+    });
+    await waitForCheckoutReady();
+    clearOperations();
+
+    await user.click(await clickSubmitButton(/complete your order/i));
+
+    await waitFor(() => {
+      expect(document.body).toHaveTextContent(enUs.validation.enterFirstName);
+    });
+    expect(getOperations('ConfirmCheckoutSession')).toHaveLength(0);
+  });
+
   it('pins current paid pickup card behavior when the billing address line is empty', async () => {
     const draftOrder = makePaidPickupOrder();
     const { user } = renderCheckout({

--- a/packages/react/src/components/checkout/__tests__/checkout-free-payment-form.test.tsx
+++ b/packages/react/src/components/checkout/__tests__/checkout-free-payment-form.test.tsx
@@ -212,8 +212,6 @@ describe('Checkout FreePaymentForm integration', () => {
     await typeIntoNamedField(user, 'billingFirstName', 'Immediate');
     await typeIntoNamedField(user, 'billingLastName', 'Pickup');
 
-    // Intentionally do NOT advance AddressForm debounce — confirm must still
-    // queue and flush the current form names before ConfirmCheckoutSession.
     clearOperations();
     await user.click(
       await screen.findByRole('button', { name: /complete your free order/i })

--- a/packages/react/src/components/checkout/__tests__/checkout-free-payment-form.test.tsx
+++ b/packages/react/src/components/checkout/__tests__/checkout-free-payment-form.test.tsx
@@ -53,7 +53,7 @@ async function submitFreeOrder(
 }
 
 describe('Checkout FreePaymentForm integration', () => {
-  it('renders names-only billing for a free pickup order without a billing address', async () => {
+  it('renders pickup customer names in the pickup section for a free pickup order', async () => {
     const draftOrder = buildFreeDraftOrder({
       lineItems: [{ fulfillmentMode: 'PICKUP' }],
       billing: {
@@ -83,6 +83,9 @@ describe('Checkout FreePaymentForm integration', () => {
     expect(document.querySelector('input[name="billingLastName"]')).toHaveValue(
       'Pickup'
     );
+    expect(
+      document.querySelectorAll('input[name="billingFirstName"]')
+    ).toHaveLength(1);
     expect(
       document.querySelector('input[name="billingAddressLine1"]')
     ).not.toBeInTheDocument();

--- a/packages/react/src/components/checkout/__tests__/checkout-free-payment-form.test.tsx
+++ b/packages/react/src/components/checkout/__tests__/checkout-free-payment-form.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import {
   advanceCheckoutDebounce,
@@ -6,12 +6,17 @@ import {
   buildDraftOrder,
   buildShippingRates,
   clearOperations,
+  getOperationOrder,
   getOperations,
   renderCheckout,
+  typeIntoNamedField,
   waitForCheckoutReady,
   waitForOperation,
 } from './checkout-test-env';
-import { getLastConfirmInput } from './checkout-test-fixtures';
+import {
+  getLastConfirmInput,
+  getLastUpdateInput,
+} from './checkout-test-fixtures';
 
 function buildFreeDraftOrder(
   overrides: Parameters<typeof buildDraftOrder>[0] = {}
@@ -181,5 +186,52 @@ describe('Checkout FreePaymentForm integration', () => {
     expect(
       document.querySelector('input[name="shippingAddressLine1"]')
     ).not.toBeInTheDocument();
+  });
+
+  it('persists pickup billing names before free-order confirmation without waiting for debounce', async () => {
+    const draftOrder = buildFreeDraftOrder({
+      lineItems: [{ fulfillmentMode: 'PICKUP' }],
+      billing: {
+        firstName: '',
+        lastName: '',
+        phone: '',
+        email: 'jane@example.com',
+        address: null,
+      },
+    });
+    const session = buildCheckoutSession({
+      draftOrder,
+      enableShipping: false,
+      enableLocalPickup: true,
+      enableTaxCollection: false,
+    });
+
+    const { user } = renderCheckout({ session, draftOrder });
+    await waitForCheckoutReady();
+
+    await typeIntoNamedField(user, 'billingFirstName', 'Immediate');
+    await typeIntoNamedField(user, 'billingLastName', 'Pickup');
+
+    // Intentionally do NOT advance AddressForm debounce — confirm must still
+    // queue and flush the current form names before ConfirmCheckoutSession.
+    clearOperations();
+    await user.click(
+      await screen.findByRole('button', { name: /complete your free order/i })
+    );
+    await waitForOperation('ConfirmCheckoutSession');
+
+    const [updateIdx, confirmIdx] = getOperationOrder([
+      'UpdateCheckoutSessionDraftOrder',
+      'ConfirmCheckoutSession',
+    ]);
+    expect(updateIdx).toBeGreaterThanOrEqual(0);
+    expect(confirmIdx).toBeGreaterThan(updateIdx);
+    expect(getLastUpdateInput()).toMatchObject({
+      billing: {
+        firstName: 'Immediate',
+        lastName: 'Pickup',
+      },
+    });
+    expect(getLastUpdateInput()?.billing).not.toHaveProperty('address');
   });
 });

--- a/packages/react/src/components/checkout/__tests__/checkout-pickup.test.tsx
+++ b/packages/react/src/components/checkout/__tests__/checkout-pickup.test.tsx
@@ -38,8 +38,6 @@ describe('Checkout pickup behavior', () => {
     });
     await waitForCheckoutReady();
 
-    // Names live in Pickup only; CreditCardContainer/ACH billing forms hide
-    // duplicate name inputs while still collecting the billing address.
     expect(
       document.querySelectorAll('input[name="billingFirstName"]')
     ).toHaveLength(1);

--- a/packages/react/src/components/checkout/__tests__/checkout-pickup.test.tsx
+++ b/packages/react/src/components/checkout/__tests__/checkout-pickup.test.tsx
@@ -25,6 +25,32 @@ describe('Checkout pickup behavior', () => {
     ).toBeInTheDocument();
   });
 
+  it('keeps a single set of name fields for paid pickup with credit-card billing', async () => {
+    renderCheckout({
+      draftOrderOverrides: {
+        lineItems: [{ fulfillmentMode: 'PICKUP' }],
+      },
+      sessionOverrides: {
+        enableShipping: false,
+        enableLocalPickup: true,
+        enableBillingAddressCollection: true,
+      },
+    });
+    await waitForCheckoutReady();
+
+    // Names live in Pickup only; CreditCardContainer/ACH billing forms hide
+    // duplicate name inputs while still collecting the billing address.
+    expect(
+      document.querySelectorAll('input[name="billingFirstName"]')
+    ).toHaveLength(1);
+    expect(
+      document.querySelectorAll('input[name="billingLastName"]')
+    ).toHaveLength(1);
+    expect(
+      document.querySelector('input[name="billingAddressLine1"]')
+    ).toBeInTheDocument();
+  });
+
   it('switches from shipping to pickup and calculates taxes with pickup location', async () => {
     const { user } = renderCheckout();
     await waitForCheckoutReady();

--- a/packages/react/src/components/checkout/__tests__/checkout-pickup.test.tsx
+++ b/packages/react/src/components/checkout/__tests__/checkout-pickup.test.tsx
@@ -11,8 +11,11 @@ import {
 
 describe('Checkout pickup behavior', () => {
   it('shows customer name fields in the pickup section', async () => {
-    renderCheckout();
+    const { user } = renderCheckout();
     await waitForCheckoutReady();
+
+    await user.click(screen.getByRole('radio', { name: /local pickup/i }));
+    await waitForOperation('ApplyCheckoutSessionFulfillmentLocation');
 
     expect(
       document.querySelector('input[name="billingFirstName"]')

--- a/packages/react/src/components/checkout/__tests__/checkout-pickup.test.tsx
+++ b/packages/react/src/components/checkout/__tests__/checkout-pickup.test.tsx
@@ -49,6 +49,30 @@ describe('Checkout pickup behavior', () => {
     ).toBeInTheDocument();
   });
 
+  it('keeps a single set of name fields for paid pickup when billing address collection is disabled', async () => {
+    renderCheckout({
+      draftOrderOverrides: {
+        lineItems: [{ fulfillmentMode: 'PICKUP' }],
+      },
+      sessionOverrides: {
+        enableShipping: false,
+        enableLocalPickup: true,
+        enableBillingAddressCollection: false,
+      },
+    });
+    await waitForCheckoutReady();
+
+    expect(
+      document.querySelectorAll('input[name="billingFirstName"]')
+    ).toHaveLength(1);
+    expect(
+      document.querySelectorAll('input[name="billingLastName"]')
+    ).toHaveLength(1);
+    expect(
+      document.querySelector('input[name="billingAddressLine1"]')
+    ).not.toBeInTheDocument();
+  });
+
   it('switches from shipping to pickup and calculates taxes with pickup location', async () => {
     const { user } = renderCheckout();
     await waitForCheckoutReady();

--- a/packages/react/src/components/checkout/__tests__/checkout-pickup.test.tsx
+++ b/packages/react/src/components/checkout/__tests__/checkout-pickup.test.tsx
@@ -10,6 +10,18 @@ import {
 } from './checkout-test-env';
 
 describe('Checkout pickup behavior', () => {
+  it('shows customer name fields in the pickup section', async () => {
+    renderCheckout();
+    await waitForCheckoutReady();
+
+    expect(
+      document.querySelector('input[name="billingFirstName"]')
+    ).toBeInTheDocument();
+    expect(
+      document.querySelector('input[name="billingLastName"]')
+    ).toBeInTheDocument();
+  });
+
   it('switches from shipping to pickup and calculates taxes with pickup location', async () => {
     const { user } = renderCheckout();
     await waitForCheckoutReady();

--- a/packages/react/src/components/checkout/address/address-form.tsx
+++ b/packages/react/src/components/checkout/address/address-form.tsx
@@ -169,6 +169,8 @@ export function AddressForm({
     !!lastName?.trim() &&
     debouncedContact === serializedContact;
 
+  // Names-only sync must omit `address`. Sending `address: null` clears any
+  // billing address already collected for paid pickup (Payment section).
   useDraftOrderFieldSync({
     key: 'name',
     data: contact,
@@ -180,7 +182,6 @@ export function AddressForm({
       const fields = {
         firstName: data.firstName.trim(),
         lastName: data.lastName.trim(),
-        address: null,
       };
 
       return mapAddressFieldsToInput(
@@ -522,46 +523,48 @@ export function AddressForm({
       )}
 
       {showNames ? (
-      <div className='grid grid-cols-1 sm:grid-cols-2 gap-2'>
-        <FormField
-          control={form.control}
-          name={`${sectionKey}FirstName`}
-          render={({ field, fieldState }) => (
-            <FormItem className='space-y-1'>
-              <FormLabel className='sr-only'>{t.shipping.firstName}</FormLabel>
-              <FormControl>
-                <Input
-                  placeholder={t.shipping.firstName}
-                  hasError={!!fieldState.error}
-                  aria-required={requiredFields?.[`${sectionKey}FirstName`]}
-                  {...field}
-                  disabled={isConfirmingCheckout}
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-        <FormField
-          control={form.control}
-          name={`${sectionKey}LastName`}
-          render={({ field, fieldState }) => (
-            <FormItem className='space-y-1'>
-              <FormLabel className='sr-only'>{t.shipping.lastName}</FormLabel>
-              <FormControl>
-                <Input
-                  placeholder={t.shipping.lastName}
-                  hasError={!!fieldState.error}
-                  aria-required={requiredFields?.[`${sectionKey}LastName`]}
-                  {...field}
-                  disabled={isConfirmingCheckout}
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-      </div>
+        <div className='grid grid-cols-1 sm:grid-cols-2 gap-2'>
+          <FormField
+            control={form.control}
+            name={`${sectionKey}FirstName`}
+            render={({ field, fieldState }) => (
+              <FormItem className='space-y-1'>
+                <FormLabel className='sr-only'>
+                  {t.shipping.firstName}
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder={t.shipping.firstName}
+                    hasError={!!fieldState.error}
+                    aria-required={requiredFields?.[`${sectionKey}FirstName`]}
+                    {...field}
+                    disabled={isConfirmingCheckout}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name={`${sectionKey}LastName`}
+            render={({ field, fieldState }) => (
+              <FormItem className='space-y-1'>
+                <FormLabel className='sr-only'>{t.shipping.lastName}</FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder={t.shipping.lastName}
+                    hasError={!!fieldState.error}
+                    aria-required={requiredFields?.[`${sectionKey}LastName`]}
+                    {...field}
+                    disabled={isConfirmingCheckout}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
       ) : null}
 
       {showAddressFields ? (

--- a/packages/react/src/components/checkout/address/address-form.tsx
+++ b/packages/react/src/components/checkout/address/address-form.tsx
@@ -54,8 +54,10 @@ import type { Address } from '@/types';
 
 interface AddressFormProps {
   sectionKey: string;
-  /** When true, only show first name and last name fields (used for free pickup orders) */
+  /** When true, only show first name and last name fields (used for pickup orders) */
   onlyNames?: boolean;
+  /** When true, hide first/last name fields (names collected elsewhere, e.g. pickup section) */
+  hideNames?: boolean;
 }
 
 export function mapAutocompleteAddressFields(selectedAddress?: Address) {
@@ -73,7 +75,10 @@ export function mapAutocompleteAddressFields(selectedAddress?: Address) {
 export function AddressForm({
   sectionKey,
   onlyNames = false,
+  hideNames = false,
 }: AddressFormProps) {
+  const showNames = onlyNames || !hideNames;
+  const showAddressFields = !onlyNames;
   const form = useFormContext();
   const { session } = useCheckoutContext();
   const { t } = useGoDaddyContext();
@@ -389,7 +394,7 @@ export function AddressForm({
 
   return (
     <fieldset className='space-y-2' disabled={isConfirmingCheckout}>
-      {!onlyNames && (
+      {showAddressFields && (
         <FormField
           control={form.control}
           name={`${sectionKey}CountryCode`}
@@ -516,6 +521,7 @@ export function AddressForm({
         />
       )}
 
+      {showNames ? (
       <div className='grid grid-cols-1 sm:grid-cols-2 gap-2'>
         <FormField
           control={form.control}
@@ -556,8 +562,9 @@ export function AddressForm({
           )}
         />
       </div>
+      ) : null}
 
-      {!onlyNames && (
+      {showAddressFields ? (
         <>
           <FormField
             control={form.control}
@@ -764,7 +771,7 @@ export function AddressForm({
 
           <PhoneInput sectionKey={sectionKey} disabled={isConfirmingCheckout} />
         </>
-      )}
+      ) : null}
     </fieldset>
   );
 }

--- a/packages/react/src/components/checkout/checkout.tsx
+++ b/packages/react/src/components/checkout/checkout.tsx
@@ -317,7 +317,8 @@ export function Checkout(props: CheckoutProps) {
 
       const requireBillingNamesOnly =
         !isPickup &&
-        (!enableBillingAddressCollection && billingIsSeparateFromShipping);
+        !enableBillingAddressCollection &&
+        billingIsSeparateFromShipping;
 
       if (requireBillingNamesOnly) {
         for (const { key, message } of billingNameFields) {

--- a/packages/react/src/components/checkout/checkout.tsx
+++ b/packages/react/src/components/checkout/checkout.tsx
@@ -282,12 +282,12 @@ export function Checkout(props: CheckoutProps) {
         }
       }
 
-      // Billing address validation - only required if not using shipping address OR pickup
-      // BUT skip for free orders (paymentMethod === 'offline')
-      const isFreeOrder = data.paymentMethod === PaymentMethodType.OFFLINE;
+      // Billing address validation - only required when billing is separate from shipping.
+      // Offline pickup (pay in store / $0 order) only requires customer names.
+      const isOfflinePayment = data.paymentMethod === PaymentMethodType.OFFLINE;
       const isPickup = data.deliveryMethod === DeliveryMethods.PICKUP;
       const isShipping = data.deliveryMethod === DeliveryMethods.SHIP;
-      const isFreePickup = isFreeOrder && isPickup;
+      const isOfflinePickup = isOfflinePayment && isPickup;
 
       // Billing is separate from shipping when there is no shipping address
       // to copy from. `mapOrderToFormValues` canonicalizes deliveryMethod
@@ -297,18 +297,31 @@ export function Checkout(props: CheckoutProps) {
       const billingIsSeparateFromShipping =
         !isShipping || !data.paymentUseShippingAddress;
 
+      const billingNameFields = [
+        { key: 'billingFirstName', message: t.validation.enterFirstName },
+        { key: 'billingLastName', message: t.validation.enterLastName },
+      ];
+
+      // Pickup orders always require customer name (collected in Pickup section).
+      if (isPickup) {
+        for (const { key, message } of billingNameFields) {
+          if (!String(data[key as keyof typeof data] ?? '').trim()) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message,
+              path: [key],
+            });
+          }
+        }
+      }
+
       const requireBillingNamesOnly =
-        (!enableBillingAddressCollection && billingIsSeparateFromShipping) ||
-        isFreePickup;
+        !isPickup &&
+        (!enableBillingAddressCollection && billingIsSeparateFromShipping);
 
       if (requireBillingNamesOnly) {
-        const nameFields = [
-          { key: 'billingFirstName', message: t.validation.enterFirstName },
-          { key: 'billingLastName', message: t.validation.enterLastName },
-        ];
-
-        for (const { key, message } of nameFields) {
-          if (!data[key as keyof typeof data]) {
+        for (const { key, message } of billingNameFields) {
+          if (!String(data[key as keyof typeof data] ?? '').trim()) {
             ctx.addIssue({
               code: z.ZodIssueCode.custom,
               message,
@@ -320,7 +333,7 @@ export function Checkout(props: CheckoutProps) {
 
       const requireBillingAddress =
         enableBillingAddressCollection &&
-        !isFreePickup &&
+        !isOfflinePickup &&
         billingIsSeparateFromShipping;
 
       if (requireBillingAddress) {

--- a/packages/react/src/components/checkout/form/custom-form-provider.tsx
+++ b/packages/react/src/components/checkout/form/custom-form-provider.tsx
@@ -56,15 +56,15 @@ export function CustomFormProvider<
             values.paymentUseShippingAddress as unknown as boolean;
           const isPickup = deliveryMethod === DeliveryMethods.PICKUP;
           const isShipping = deliveryMethod === DeliveryMethods.SHIP;
-          const isFreeOrder = paymentMethod === PaymentMethodType.OFFLINE;
-          const isFreePickup = isFreeOrder && isPickup;
+          const isOfflinePayment = paymentMethod === PaymentMethodType.OFFLINE;
+          const isOfflinePickup = isOfflinePayment && isPickup;
 
           // Get all field names and filter based on conditions
           const allFieldNames = Object.keys(values);
           let fieldNames = [...allFieldNames] as Array<FieldPath<TFormValues>>;
 
-          /* For free pickup orders, only validate billingFirstName and billingLastName */
-          if (isFreePickup) {
+          /* Offline pickup only validates billing name fields among billing inputs */
+          if (isOfflinePickup) {
             fieldNames = fieldNames.filter(
               fieldName =>
                 !fieldName.startsWith('billing') ||
@@ -90,7 +90,7 @@ export function CustomFormProvider<
 
           // Trigger validation only on the filtered fields if any condition is true,
           // otherwise trigger on all fields
-          if (paymentUseShippingAddress || isPickup || isFreeOrder) {
+          if (paymentUseShippingAddress || isPickup || isOfflinePayment) {
             result = await methods.trigger(fieldNames, triggerOptions);
           } else {
             result = await methods.trigger(undefined, triggerOptions);

--- a/packages/react/src/components/checkout/payment/checkout-buttons/express/godaddy.tsx
+++ b/packages/react/src/components/checkout/payment/checkout-buttons/express/godaddy.tsx
@@ -197,8 +197,6 @@ export function ExpressCheckoutButton() {
         return;
       }
 
-      // Persist pickup names before the wallet opens (AddressForm debounce may
-      // not have enqueued a draft-order patch yet).
       await syncPickupBillingNames();
 
       // Read from refs to get current values (avoid stale closure)

--- a/packages/react/src/components/checkout/payment/checkout-buttons/express/godaddy.tsx
+++ b/packages/react/src/components/checkout/payment/checkout-buttons/express/godaddy.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useFormContext } from 'react-hook-form';
 import { useCheckoutContext } from '@/components/checkout/checkout';
+import type { CheckoutFormData } from '@/components/checkout/checkout';
 import { useGetPriceAdjustments } from '@/components/checkout/discount/utils/use-get-price-adjustments';
 import {
   useDraftOrder,
@@ -27,6 +29,7 @@ import { useLoadPoyntCollect } from '@/components/checkout/payment/utils/use-loa
 import { filterAndSortShippingMethods } from '@/components/checkout/shipping/utils/filter-shipping-methods';
 import { useGetShippingMethodByAddress } from '@/components/checkout/shipping/utils/use-get-shipping-methods';
 import { useGetTaxes } from '@/components/checkout/taxes/utils/use-get-taxes';
+import { validatePickupPrerequisites } from '@/components/checkout/utils/use-validate-pickup-prerequisites';
 import {
   useConvertMajorToMinorUnits,
   useFormatCurrency,
@@ -45,6 +48,7 @@ import type { CalculatedAdjustments, CalculatedTaxes } from '@/types';
 export function ExpressCheckoutButton() {
   const formatCurrency = useFormatCurrency();
   const convertMajorToMinorUnits = useConvertMajorToMinorUnits();
+  const form = useFormContext<CheckoutFormData>();
   const { session, setCheckoutErrors, isConfirmingCheckout } =
     useCheckoutContext();
   const isPaymentDisabled = useIsPaymentDisabled();
@@ -186,6 +190,11 @@ export function ExpressCheckoutButton() {
         return;
       }
 
+      const pickupValid = await validatePickupPrerequisites(form, session);
+      if (!pickupValid) {
+        return;
+      }
+
       // Read from refs to get current values (avoid stale closure)
       const currentCouponCode = appliedCouponCodeRef.current;
       const currentAdjustments = calculatedAdjustmentsRef.current;
@@ -296,6 +305,8 @@ export function ExpressCheckoutButton() {
       totals,
       formatCurrency,
       isDisabled,
+      form,
+      session,
     ]
   );
 

--- a/packages/react/src/components/checkout/payment/checkout-buttons/express/godaddy.tsx
+++ b/packages/react/src/components/checkout/payment/checkout-buttons/express/godaddy.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
-import { useCheckoutContext } from '@/components/checkout/checkout';
 import type { CheckoutFormData } from '@/components/checkout/checkout';
+import { useCheckoutContext } from '@/components/checkout/checkout';
 import { useGetPriceAdjustments } from '@/components/checkout/discount/utils/use-get-price-adjustments';
 import {
   useDraftOrder,
@@ -29,11 +29,12 @@ import { useLoadPoyntCollect } from '@/components/checkout/payment/utils/use-loa
 import { filterAndSortShippingMethods } from '@/components/checkout/shipping/utils/filter-shipping-methods';
 import { useGetShippingMethodByAddress } from '@/components/checkout/shipping/utils/use-get-shipping-methods';
 import { useGetTaxes } from '@/components/checkout/taxes/utils/use-get-taxes';
-import { validatePickupPrerequisites } from '@/components/checkout/utils/use-validate-pickup-prerequisites';
 import {
   useConvertMajorToMinorUnits,
   useFormatCurrency,
 } from '@/components/checkout/utils/format-currency';
+import { useSyncPickupBillingNames } from '@/components/checkout/utils/use-sync-pickup-billing-names';
+import { validatePickupPrerequisites } from '@/components/checkout/utils/use-validate-pickup-prerequisites';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useGoDaddyContext } from '@/godaddy-provider';
 import { GraphQLErrorWithCodes } from '@/lib/graphql-with-errors';
@@ -53,6 +54,7 @@ export function ExpressCheckoutButton() {
     useCheckoutContext();
   const isPaymentDisabled = useIsPaymentDisabled();
   const { isPoyntLoaded } = useLoadPoyntCollect();
+  const syncPickupBillingNames = useSyncPickupBillingNames();
 
   const isDisabled = isConfirmingCheckout || isPaymentDisabled;
   const { godaddyPaymentsConfig } = useCheckoutContext();
@@ -195,6 +197,10 @@ export function ExpressCheckoutButton() {
         return;
       }
 
+      // Persist pickup names before the wallet opens (AddressForm debounce may
+      // not have enqueued a draft-order patch yet).
+      await syncPickupBillingNames();
+
       // Read from refs to get current values (avoid stale closure)
       const currentCouponCode = appliedCouponCodeRef.current;
       const currentAdjustments = calculatedAdjustmentsRef.current;
@@ -307,6 +313,7 @@ export function ExpressCheckoutButton() {
       isDisabled,
       form,
       session,
+      syncPickupBillingNames,
     ]
   );
 

--- a/packages/react/src/components/checkout/payment/checkout-buttons/express/godaddy.tsx
+++ b/packages/react/src/components/checkout/payment/checkout-buttons/express/godaddy.tsx
@@ -100,6 +100,9 @@ export function ExpressCheckoutButton() {
   // Use refs to store current coupon state to avoid stale closures in event handlers
   const appliedCouponCodeRef = useRef<string | null>(null);
   const calculatedAdjustmentsRef = useRef<CalculatedAdjustments | null>(null);
+  const pickupBillingNamesSyncRef = useRef<Promise<void> | null>(null);
+  const syncPickupBillingNamesRef = useRef(syncPickupBillingNames);
+  syncPickupBillingNamesRef.current = syncPickupBillingNames;
 
   const calculateGodaddyExpressTaxes = useCallback(
     async ({
@@ -197,7 +200,7 @@ export function ExpressCheckoutButton() {
         return;
       }
 
-      await syncPickupBillingNames();
+      pickupBillingNamesSyncRef.current = syncPickupBillingNames();
 
       // Read from refs to get current values (avoid stale closure)
       const currentCouponCode = appliedCouponCodeRef.current;
@@ -990,6 +993,10 @@ export function ExpressCheckoutButton() {
         };
 
         try {
+          await (pickupBillingNamesSyncRef.current ??
+            syncPickupBillingNamesRef.current());
+          pickupBillingNamesSyncRef.current = null;
+
           await confirmCheckout.mutateAsync(checkoutBody);
 
           event.complete();

--- a/packages/react/src/components/checkout/payment/checkout-buttons/express/stripe.tsx
+++ b/packages/react/src/components/checkout/payment/checkout-buttons/express/stripe.tsx
@@ -9,7 +9,9 @@ import type {
   StripeExpressCheckoutElementShippingRateChangeEvent,
 } from '@stripe/stripe-js';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useFormContext } from 'react-hook-form';
 import { useCheckoutContext } from '@/components/checkout/checkout';
+import type { CheckoutFormData } from '@/components/checkout/checkout';
 import { useGetPriceAdjustments } from '@/components/checkout/discount/utils/use-get-price-adjustments';
 import {
   useDraftOrder,
@@ -21,6 +23,7 @@ import { useStripePaymentIntent } from '@/components/checkout/payment/utils/use-
 import { filterAndSortShippingMethods } from '@/components/checkout/shipping/utils/filter-shipping-methods';
 import { useGetShippingMethodByAddress } from '@/components/checkout/shipping/utils/use-get-shipping-methods';
 import { useGetTaxes } from '@/components/checkout/taxes/utils/use-get-taxes';
+import { validatePickupPrerequisites } from '@/components/checkout/utils/use-validate-pickup-prerequisites';
 
 import { Skeleton } from '@/components/ui/skeleton';
 import { useGoDaddyContext } from '@/godaddy-provider';
@@ -42,6 +45,7 @@ interface StripePartialAddress {
 
 export function StripeExpressCheckoutForm() {
   const { t } = useGoDaddyContext();
+  const form = useFormContext<CheckoutFormData>();
   const { session, setCheckoutErrors, isConfirmingCheckout } =
     useCheckoutContext();
   const elements = useElements();
@@ -369,9 +373,15 @@ export function StripeExpressCheckoutForm() {
 
   // Handle click event - configure initial details
   const handleClick = useCallback(
-    (event: StripeExpressCheckoutElementClickEvent) => {
+    async (event: StripeExpressCheckoutElementClickEvent) => {
       // Reject if payment is disabled
       if (isDisabled) {
+        event.reject();
+        return;
+      }
+
+      const pickupValid = await validatePickupPrerequisites(form, session);
+      if (!pickupValid) {
         event.reject();
         return;
       }
@@ -404,7 +414,7 @@ export function StripeExpressCheckoutForm() {
         lineItems: buildLineItems({ discountAmount }),
       });
     },
-    [buildLineItems, setCheckoutErrors, isDisabled]
+    [buildLineItems, setCheckoutErrors, isDisabled, form, session]
   );
 
   // Handle shipping address change

--- a/packages/react/src/components/checkout/payment/checkout-buttons/express/stripe.tsx
+++ b/packages/react/src/components/checkout/payment/checkout-buttons/express/stripe.tsx
@@ -10,8 +10,8 @@ import type {
 } from '@stripe/stripe-js';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
-import { useCheckoutContext } from '@/components/checkout/checkout';
 import type { CheckoutFormData } from '@/components/checkout/checkout';
+import { useCheckoutContext } from '@/components/checkout/checkout';
 import { useGetPriceAdjustments } from '@/components/checkout/discount/utils/use-get-price-adjustments';
 import {
   useDraftOrder,
@@ -23,6 +23,7 @@ import { useStripePaymentIntent } from '@/components/checkout/payment/utils/use-
 import { filterAndSortShippingMethods } from '@/components/checkout/shipping/utils/filter-shipping-methods';
 import { useGetShippingMethodByAddress } from '@/components/checkout/shipping/utils/use-get-shipping-methods';
 import { useGetTaxes } from '@/components/checkout/taxes/utils/use-get-taxes';
+import { useSyncPickupBillingNames } from '@/components/checkout/utils/use-sync-pickup-billing-names';
 import { validatePickupPrerequisites } from '@/components/checkout/utils/use-validate-pickup-prerequisites';
 
 import { Skeleton } from '@/components/ui/skeleton';
@@ -50,6 +51,7 @@ export function StripeExpressCheckoutForm() {
     useCheckoutContext();
   const elements = useElements();
   const isPaymentDisabled = useIsPaymentDisabled();
+  const syncPickupBillingNames = useSyncPickupBillingNames();
   const { handleSubmit } = useStripeCheckout({
     mode: 'express',
   });
@@ -386,6 +388,10 @@ export function StripeExpressCheckoutForm() {
         return;
       }
 
+      // Persist pickup names before the wallet opens (AddressForm debounce may
+      // not have enqueued a draft-order patch yet).
+      await syncPickupBillingNames();
+
       // Track click
       if (event.expressPaymentType === 'apple_pay') {
         track({
@@ -414,7 +420,14 @@ export function StripeExpressCheckoutForm() {
         lineItems: buildLineItems({ discountAmount }),
       });
     },
-    [buildLineItems, setCheckoutErrors, isDisabled, form, session]
+    [
+      buildLineItems,
+      setCheckoutErrors,
+      isDisabled,
+      form,
+      session,
+      syncPickupBillingNames,
+    ]
   );
 
   // Handle shipping address change

--- a/packages/react/src/components/checkout/payment/checkout-buttons/express/stripe.tsx
+++ b/packages/react/src/components/checkout/payment/checkout-buttons/express/stripe.tsx
@@ -388,8 +388,6 @@ export function StripeExpressCheckoutForm() {
         return;
       }
 
-      // Persist pickup names before the wallet opens (AddressForm debounce may
-      // not have enqueued a draft-order patch yet).
       await syncPickupBillingNames();
 
       // Track click

--- a/packages/react/src/components/checkout/payment/checkout-buttons/express/stripe.tsx
+++ b/packages/react/src/components/checkout/payment/checkout-buttons/express/stripe.tsx
@@ -88,6 +88,7 @@ export function StripeExpressCheckoutForm() {
   // Use refs for values needed in event handlers to avoid stale closures
   const appliedCouponCodeRef = useRef<string | null>(null);
   const calculatedAdjustmentsRef = useRef<CalculatedAdjustments | null>(null);
+  const pickupBillingNamesSyncRef = useRef<Promise<void> | null>(null);
 
   // Extract discount codes from draft order for comparison (stable string)
   const draftOrderDiscountCodes = useMemo(() => {
@@ -388,7 +389,7 @@ export function StripeExpressCheckoutForm() {
         return;
       }
 
-      await syncPickupBillingNames();
+      pickupBillingNamesSyncRef.current = syncPickupBillingNames();
 
       // Track click
       if (event.expressPaymentType === 'apple_pay') {
@@ -586,6 +587,9 @@ export function StripeExpressCheckoutForm() {
   const handleConfirm = useCallback(
     async (event: StripeExpressCheckoutElementConfirmEvent) => {
       try {
+        await (pickupBillingNamesSyncRef.current ?? syncPickupBillingNames());
+        pickupBillingNamesSyncRef.current = null;
+
         // Find the selected shipping method from our stored shipping methods
         const selectedShippingMethod = shippingMethods?.find(
           method =>
@@ -636,6 +640,7 @@ export function StripeExpressCheckoutForm() {
     },
     [
       handleSubmit,
+      syncPickupBillingNames,
       t.errors.errorProcessingPayment,
       shippingMethods,
       selectedShippingRate,
@@ -647,6 +652,7 @@ export function StripeExpressCheckoutForm() {
   // Handle cancel event
   const handleCancel = useCallback(() => {
     // Reset state when payment sheet is dismissed
+    pickupBillingNamesSyncRef.current = null;
     setCalculatedTaxes(null);
     setShippingMethods(null);
     setSelectedShippingRate(null);

--- a/packages/react/src/components/checkout/payment/free-payment-form.tsx
+++ b/packages/react/src/components/checkout/payment/free-payment-form.tsx
@@ -1,9 +1,7 @@
 import { LoaderCircle } from 'lucide-react';
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
-import { AddressForm } from '@/components/checkout/address/address-form';
 import { useCheckoutContext } from '@/components/checkout/checkout';
-import { DeliveryMethods } from '@/components/checkout/delivery/delivery-methods';
 import {
   PaymentProvider,
   useConfirmCheckout,
@@ -21,9 +19,6 @@ export function FreePaymentForm() {
   const isPaymentDisabled = useIsPaymentDisabled();
   const form = useFormContext();
   const confirmCheckout = useConfirmCheckout();
-
-  const deliveryMethod = form.watch('deliveryMethod');
-  const isPickup = deliveryMethod === DeliveryMethods.PICKUP;
 
   const handleSubmit = React.useCallback(async () => {
     const valid = await form.trigger();
@@ -48,16 +43,20 @@ export function FreePaymentForm() {
     }
   }, [form, confirmCheckout.mutateAsync, setCheckoutErrors]);
 
-  const submitButton = isConfirmingCheckout ? (
-    <Button
-      type='button'
-      className='w-full flex items-center justify-center gap-2 px-8 h-10'
-      disabled
-    >
-      <LoaderCircle className='h-5 w-5 animate-spin' />
-      {t.payment.completingOrder}
-    </Button>
-  ) : (
+  if (isConfirmingCheckout) {
+    return (
+      <Button
+        type='button'
+        className='w-full flex items-center justify-center gap-2 px-8 h-10'
+        disabled
+      >
+        <LoaderCircle className='h-5 w-5 animate-spin' />
+        {t.payment.completingOrder}
+      </Button>
+    );
+  }
+
+  return (
     <Button
       className={cn('w-full')}
       size='lg'
@@ -68,16 +67,4 @@ export function FreePaymentForm() {
       <span>{t.payment.freePayment}</span>
     </Button>
   );
-
-  // For pickup orders, show name fields
-  if (isPickup) {
-    return (
-      <div className='space-y-4'>
-        <AddressForm sectionKey='billing' onlyNames />
-        {submitButton}
-      </div>
-    );
-  }
-
-  return submitButton;
 }

--- a/packages/react/src/components/checkout/payment/payment-form.tsx
+++ b/packages/react/src/components/checkout/payment/payment-form.tsx
@@ -308,6 +308,7 @@ export function PaymentForm(
   const billingIsSeparateFromShipping = !isShipping || !useShippingAddress;
 
   const shouldShowBillingNamesOnly =
+    !isPickup &&
     !isPaymentMethodWithInlineBilling &&
     session?.enableBillingAddressCollection === false &&
     billingIsSeparateFromShipping;
@@ -569,6 +570,7 @@ export function PaymentForm(
           <AddressForm
             sectionKey='billing'
             onlyNames={shouldShowBillingNamesOnly}
+            hideNames={isPickup && isBillingAddressRequired}
           />
         </CheckoutSection>
       ) : null}

--- a/packages/react/src/components/checkout/payment/payment-methods/ach/godaddy.tsx
+++ b/packages/react/src/components/checkout/payment/payment-methods/ach/godaddy.tsx
@@ -34,6 +34,7 @@ export function GoDaddyACHForm() {
   const useShippingAddress = form.watch('paymentUseShippingAddress');
   const deliveryMethod = form.watch('deliveryMethod');
   const isShipping = deliveryMethod === DeliveryMethods.SHIP;
+  const isPickup = deliveryMethod === DeliveryMethods.PICKUP;
 
   // Billing is separate from shipping when there is no shipping address to
   // copy from. `mapOrderToFormValues` canonicalizes deliveryMethod against
@@ -276,6 +277,7 @@ export function GoDaddyACHForm() {
           <AddressForm
             sectionKey='billing'
             onlyNames={shouldShowBillingNamesOnly}
+            hideNames={isPickup && isBillingAddressRequired}
           />
         </CheckoutSection>
       ) : null}

--- a/packages/react/src/components/checkout/payment/payment-methods/ach/godaddy.tsx
+++ b/packages/react/src/components/checkout/payment/payment-methods/ach/godaddy.tsx
@@ -45,6 +45,7 @@ export function GoDaddyACHForm() {
   const billingIsSeparateFromShipping = !isShipping || !useShippingAddress;
 
   const shouldShowBillingNamesOnly =
+    !isPickup &&
     paymentMethod === PaymentMethodType.ACH &&
     session?.enableBillingAddressCollection === false &&
     billingIsSeparateFromShipping;

--- a/packages/react/src/components/checkout/payment/payment-methods/credit-card/container.tsx
+++ b/packages/react/src/components/checkout/payment/payment-methods/credit-card/container.tsx
@@ -18,6 +18,7 @@ export function CreditCardContainer({ children }: { children?: ReactNode }) {
   const useShippingAddress = form.watch('paymentUseShippingAddress');
   const deliveryMethod = form.watch('deliveryMethod');
   const isShipping = deliveryMethod === DeliveryMethods.SHIP;
+  const isPickup = deliveryMethod === DeliveryMethods.PICKUP;
 
   // Billing is separate from shipping when there is no shipping address to
   // copy from. `mapOrderToFormValues` canonicalizes deliveryMethod against
@@ -72,6 +73,7 @@ export function CreditCardContainer({ children }: { children?: ReactNode }) {
           <AddressForm
             sectionKey='billing'
             onlyNames={shouldShowBillingNamesOnly}
+            hideNames={isPickup && isBillingAddressRequired}
           />
         </CheckoutSection>
       ) : null}

--- a/packages/react/src/components/checkout/payment/payment-methods/credit-card/container.tsx
+++ b/packages/react/src/components/checkout/payment/payment-methods/credit-card/container.tsx
@@ -29,6 +29,7 @@ export function CreditCardContainer({ children }: { children?: ReactNode }) {
   const billingIsSeparateFromShipping = !isShipping || !useShippingAddress;
 
   const shouldShowBillingNamesOnly =
+    !isPickup &&
     paymentMethod === PaymentMethodType.CREDIT_CARD &&
     session?.enableBillingAddressCollection === false &&
     billingIsSeparateFromShipping;

--- a/packages/react/src/components/checkout/payment/utils/use-flush-checkout-sync.ts
+++ b/packages/react/src/components/checkout/payment/utils/use-flush-checkout-sync.ts
@@ -1,11 +1,17 @@
 import { useQueryClient } from '@tanstack/react-query';
 import * as React from 'react';
-import { useCheckoutContext } from '@/components/checkout/checkout';
+import { useFormContext } from 'react-hook-form';
+import {
+  type CheckoutFormData,
+  useCheckoutContext,
+} from '@/components/checkout/checkout';
 import { useDraftOrderSyncQueue } from '@/components/checkout/order/draft-order-sync-provider';
+import { useDraftOrder } from '@/components/checkout/order/use-draft-order';
 import {
   checkoutMutationKeys,
   checkoutQueryKeys,
 } from '@/components/checkout/utils/query-keys';
+import { getPickupBillingNamesPatch } from '@/components/checkout/utils/sync-pickup-billing-names';
 
 const DEFAULT_TIMEOUT_MS = 10_000;
 const POLL_INTERVAL_MS = 50;
@@ -22,12 +28,25 @@ function delay(ms: number) {
 
 export function useFlushCheckoutSync() {
   const queryClient = useQueryClient();
+  const form = useFormContext<CheckoutFormData>();
   const { session, setCheckoutErrors } = useCheckoutContext();
-  const { flushDraftOrderSync } = useDraftOrderSyncQueue();
+  const { data: draftOrder } = useDraftOrder();
+  const { enqueueDraftOrderPatch, flushDraftOrderSync } =
+    useDraftOrderSyncQueue();
 
   return React.useCallback(
     async (options: FlushCheckoutSyncOptions = {}) => {
       try {
+        // Pickup names live in AddressForm onlyNames, which debounces before
+        // enqueue. Flush only drains already-queued patches — so queue the
+        // current form names here before draining (standard + confirm paths).
+        const pickupNamesPatch = getPickupBillingNamesPatch(form, draftOrder);
+        if (pickupNamesPatch) {
+          enqueueDraftOrderPatch(pickupNamesPatch, {
+            fieldNames: ['billingFirstName', 'billingLastName'],
+          });
+        }
+
         await flushDraftOrderSync();
 
         const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
@@ -88,6 +107,14 @@ export function useFlushCheckoutSync() {
         throw error;
       }
     },
-    [flushDraftOrderSync, queryClient, session, setCheckoutErrors]
+    [
+      draftOrder,
+      enqueueDraftOrderPatch,
+      flushDraftOrderSync,
+      form,
+      queryClient,
+      session,
+      setCheckoutErrors,
+    ]
   );
 }

--- a/packages/react/src/components/checkout/payment/utils/use-flush-checkout-sync.ts
+++ b/packages/react/src/components/checkout/payment/utils/use-flush-checkout-sync.ts
@@ -37,9 +37,6 @@ export function useFlushCheckoutSync() {
   return React.useCallback(
     async (options: FlushCheckoutSyncOptions = {}) => {
       try {
-        // Pickup names live in AddressForm onlyNames, which debounces before
-        // enqueue. Flush only drains already-queued patches — so queue the
-        // current form names here before draining (standard + confirm paths).
         const pickupNamesPatch = getPickupBillingNamesPatch(form, draftOrder);
         if (pickupNamesPatch) {
           enqueueDraftOrderPatch(pickupNamesPatch, {

--- a/packages/react/src/components/checkout/pickup/local-pickup.tsx
+++ b/packages/react/src/components/checkout/pickup/local-pickup.tsx
@@ -3,6 +3,7 @@ import { format as formatTz, toZonedTime } from 'date-fns-tz';
 import { CalendarIcon, ChevronDown, Clock, MapPin, Store } from 'lucide-react';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
+import { AddressForm } from '@/components/checkout/address/address-form';
 import { useCheckoutContext } from '@/components/checkout/checkout';
 import { DeliveryMethods } from '@/components/checkout/delivery/delivery-methods';
 import { useApplyFulfillmentLocation } from '@/components/checkout/delivery/utils/use-apply-fulfillment-location';
@@ -440,6 +441,8 @@ export function LocalPickupForm({
 
   return (
     <div className='space-y-4'>
+      <AddressForm sectionKey='billing' onlyNames />
+
       <FormField
         control={form.control}
         name='pickupLocationId'

--- a/packages/react/src/components/checkout/utils/sync-pickup-billing-names.test.ts
+++ b/packages/react/src/components/checkout/utils/sync-pickup-billing-names.test.ts
@@ -1,0 +1,73 @@
+import type { UseFormReturn } from 'react-hook-form';
+import { describe, expect, it, vi } from 'vitest';
+import type { CheckoutFormData } from '@/components/checkout/checkout';
+import { DeliveryMethods } from '@/components/checkout/delivery/delivery-methods';
+import { getPickupBillingNamesPatch } from '@/components/checkout/utils/sync-pickup-billing-names';
+import type { DraftOrder } from '@/types';
+
+function mockForm(
+  values: Partial<CheckoutFormData>
+): UseFormReturn<CheckoutFormData> {
+  return {
+    getValues: vi.fn(() => values),
+  } as unknown as UseFormReturn<CheckoutFormData>;
+}
+
+describe('getPickupBillingNamesPatch', () => {
+  it('returns null when delivery method is not pickup', () => {
+    const form = mockForm({
+      deliveryMethod: DeliveryMethods.SHIP,
+      billingFirstName: 'Jane',
+      billingLastName: 'Doe',
+    });
+
+    expect(getPickupBillingNamesPatch(form, null)).toBeNull();
+  });
+
+  it('returns null when pickup names are incomplete', () => {
+    const form = mockForm({
+      deliveryMethod: DeliveryMethods.PICKUP,
+      billingFirstName: 'Jane',
+      billingLastName: '  ',
+    });
+
+    expect(getPickupBillingNamesPatch(form, null)).toBeNull();
+  });
+
+  it('returns null when form names already match the draft order', () => {
+    const form = mockForm({
+      deliveryMethod: DeliveryMethods.PICKUP,
+      billingFirstName: 'Jane',
+      billingLastName: 'Doe',
+    });
+    const draftOrder = {
+      billing: { firstName: 'Jane', lastName: 'Doe' },
+    } as DraftOrder;
+
+    expect(getPickupBillingNamesPatch(form, draftOrder)).toBeNull();
+  });
+
+  it('returns a names-only billing patch without address', () => {
+    const form = mockForm({
+      deliveryMethod: DeliveryMethods.PICKUP,
+      billingFirstName: ' Jane ',
+      billingLastName: ' Doe ',
+    });
+    const draftOrder = {
+      billing: {
+        firstName: '',
+        lastName: '',
+        address: {
+          addressLine1: 'Paid Pickup Billing St',
+        },
+      },
+    } as DraftOrder;
+
+    expect(getPickupBillingNamesPatch(form, draftOrder)).toEqual({
+      billing: {
+        firstName: 'Jane',
+        lastName: 'Doe',
+      },
+    });
+  });
+});

--- a/packages/react/src/components/checkout/utils/sync-pickup-billing-names.ts
+++ b/packages/react/src/components/checkout/utils/sync-pickup-billing-names.ts
@@ -1,0 +1,46 @@
+import type { UseFormReturn } from 'react-hook-form';
+import type { CheckoutFormData } from '@/components/checkout/checkout';
+import { DeliveryMethods } from '@/components/checkout/delivery/delivery-methods';
+import type { DraftOrderPatch } from '@/components/checkout/order/draft-order-sync-provider';
+
+type DraftOrderBillingNames = {
+  billing?: {
+    firstName?: string | null;
+    lastName?: string | null;
+  } | null;
+} | null;
+
+/**
+ * Build a names-only billing patch for pickup when the form has names that are
+ * not yet on the draft order. Omits `address` so paid-pickup billing addresses
+ * are preserved.
+ */
+export function getPickupBillingNamesPatch(
+  form: UseFormReturn<CheckoutFormData>,
+  draftOrder?: DraftOrderBillingNames
+): DraftOrderPatch | null {
+  const values = form.getValues();
+  if (values.deliveryMethod !== DeliveryMethods.PICKUP) {
+    return null;
+  }
+
+  const firstName = String(values.billingFirstName ?? '').trim();
+  const lastName = String(values.billingLastName ?? '').trim();
+  if (!firstName || !lastName) {
+    return null;
+  }
+
+  if (
+    (draftOrder?.billing?.firstName || '') === firstName &&
+    (draftOrder?.billing?.lastName || '') === lastName
+  ) {
+    return null;
+  }
+
+  return {
+    billing: {
+      firstName,
+      lastName,
+    },
+  };
+}

--- a/packages/react/src/components/checkout/utils/use-sync-pickup-billing-names.ts
+++ b/packages/react/src/components/checkout/utils/use-sync-pickup-billing-names.ts
@@ -1,0 +1,29 @@
+import { useCallback } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { type CheckoutFormData } from '@/components/checkout/checkout';
+import { useDraftOrderSyncQueue } from '@/components/checkout/order/draft-order-sync-provider';
+import { useDraftOrder } from '@/components/checkout/order/use-draft-order';
+import { getPickupBillingNamesPatch } from '@/components/checkout/utils/sync-pickup-billing-names';
+
+/**
+ * Queue current pickup billing names immediately (bypass AddressForm debounce)
+ * and drain the draft-order sync queue. Call before confirm / express submit.
+ */
+export function useSyncPickupBillingNames() {
+  const form = useFormContext<CheckoutFormData>();
+  const { data: draftOrder } = useDraftOrder();
+  const { enqueueDraftOrderPatch, flushDraftOrderSync } =
+    useDraftOrderSyncQueue();
+
+  return useCallback(async () => {
+    const patch = getPickupBillingNamesPatch(form, draftOrder);
+    if (!patch) {
+      return;
+    }
+
+    enqueueDraftOrderPatch(patch, {
+      fieldNames: ['billingFirstName', 'billingLastName'],
+    });
+    await flushDraftOrderSync();
+  }, [enqueueDraftOrderPatch, flushDraftOrderSync, form, draftOrder]);
+}

--- a/packages/react/src/components/checkout/utils/use-validate-pickup-prerequisites.ts
+++ b/packages/react/src/components/checkout/utils/use-validate-pickup-prerequisites.ts
@@ -1,5 +1,9 @@
 import { useCallback } from 'react';
-import { useFormContext, type FieldPath, type UseFormReturn } from 'react-hook-form';
+import {
+  type FieldPath,
+  type UseFormReturn,
+  useFormContext,
+} from 'react-hook-form';
 import type { CheckoutFormData } from '@/components/checkout/checkout';
 import { DeliveryMethods } from '@/components/checkout/delivery/delivery-methods';
 import type { CheckoutSession } from '@/types';
@@ -25,8 +29,7 @@ export function getPickupPrerequisiteFields(
   const location = session?.locations?.find(
     loc => loc.id === values.pickupLocationId
   );
-  const storeHours =
-    location?.operatingHours ?? session?.defaultOperatingHours;
+  const storeHours = location?.operatingHours ?? session?.defaultOperatingHours;
 
   if (storeHours?.pickupWindowInDays !== 0) {
     fields.push('pickupDate', 'pickupTime');

--- a/packages/react/src/components/checkout/utils/use-validate-pickup-prerequisites.ts
+++ b/packages/react/src/components/checkout/utils/use-validate-pickup-prerequisites.ts
@@ -1,0 +1,60 @@
+import { useCallback } from 'react';
+import { useFormContext, type FieldPath, type UseFormReturn } from 'react-hook-form';
+import type { CheckoutFormData } from '@/components/checkout/checkout';
+import { DeliveryMethods } from '@/components/checkout/delivery/delivery-methods';
+import type { CheckoutSession } from '@/types';
+
+export function getPickupPrerequisiteFields(
+  values: Pick<
+    CheckoutFormData,
+    'deliveryMethod' | 'pickupLocationId' | 'pickupDate' | 'pickupTime'
+  >,
+  session?: CheckoutSession | null
+): Array<FieldPath<CheckoutFormData>> {
+  if (values.deliveryMethod !== DeliveryMethods.PICKUP) {
+    return [];
+  }
+
+  const fields: Array<FieldPath<CheckoutFormData>> = [
+    'contactEmail',
+    'billingFirstName',
+    'billingLastName',
+    'pickupLocationId',
+  ];
+
+  const location = session?.locations?.find(
+    loc => loc.id === values.pickupLocationId
+  );
+  const storeHours =
+    location?.operatingHours ?? session?.defaultOperatingHours;
+
+  if (storeHours?.pickupWindowInDays !== 0) {
+    fields.push('pickupDate', 'pickupTime');
+  }
+
+  return fields;
+}
+
+export async function validatePickupPrerequisites(
+  form: UseFormReturn<CheckoutFormData>,
+  session?: CheckoutSession | null
+): Promise<boolean> {
+  const values = form.getValues();
+  const fields = getPickupPrerequisiteFields(values, session);
+
+  if (fields.length === 0) {
+    return true;
+  }
+
+  return form.trigger(fields);
+}
+
+export function useValidatePickupPrerequisites(
+  session?: CheckoutSession | null
+) {
+  const form = useFormContext<CheckoutFormData>();
+
+  return useCallback(async () => {
+    return validatePickupPrerequisites(form, session);
+  }, [form, session]);
+}


### PR DESCRIPTION

## Summary

https://godaddy-corp.atlassian.net/browse/VNEXT-81889

Bruce in-person pickup checkout collected email but not customer first/last name, so completed orders often had blank names on order.billing. That broke merchant-facing Customer Info, C1, and new-order notifications.

This change:

- Adds required first/last name fields in the Pickup section (AddressForm with onlyNames)
- Persists those names on order.billing for all pickup payment paths (card, ACH, offline, free, express)
- Validates pickup names before complete / express wallet
- Hides duplicate name fields in Payment billing when pickup already collected names (hideNames on PaymentForm, CreditCard, and ACH) while still collecting billing address when required
- Free pickup shows names only in Pickup (submit button only in payment)

Package: @godaddy/react


## Changeset

- [x] Changeset added ([docs](https://github.com/godaddy/javascript#submit-a-changeset))
Added `.changeset/pickup-customer-names.md` — **patch** for `@godaddy/react`:
Require customer first and last name for in-person pickup orders. Names are collected in the Pickup section, synced to order billing, and validated for card, offline, free, and express checkout paths.

## Test Plan

### Unit tests
- [x] Address preserve: `syncs only billing names in onlyNames mode without clearing billing address`
- [x] Single name field: `keeps a single set of name fields for paid pickup with credit-card billing`
- [x] Immediate submit: `persists pickup billing names before free-order confirmation without waiting for debounce`
- [x] Pickup name field rendering / validation coverage in checkout pickup + form-validation tests
- [x] Focused suite green (`checkout-address`, `checkout-draft-order-sync`, `checkout-form-validation`, `checkout-free-payment-form`, `checkout-pickup`, `sync-pickup-billing-names`)

### Manual / consumer checks (bruce-storefront after package publish)
- [ ] **Free pickup** — enter first/last name in Pickup, click Complete immediately → order has billing names
- [ ] **Paid card pickup** — names required in Pickup; Payment shows billing address only (no duplicate name fields); names + address both on order
- [ ] **Paid ACH pickup** — same as card: single name set in Pickup, address in Payment
- [ ] **Offline pickup** — names required and persisted on billing
- [ ] **Paid pickup address preserve** — fill billing address, then edit Pickup names → draft/order still keeps billing address
- [ ] Merchant order details / notifications show customer name (billing) for pickup orders
