### PR TITLE
[YOLO-3177] feat(react): add notes prop to Checkout for custom label + placeholder

### DIFF
--- a/.changeset/notes-label-placeholder.md
+++ b/.changeset/notes-label-placeholder.md
@@ -1,0 +1,5 @@
+---
+"@godaddy/react": patch
+---
+
+Add optional `notes` prop to `Checkout` for overriding the notes-collection field's label and placeholder. Both fall back to localization (`t.general.notes` / `t.shipping.notesPlaceholder`) when omitted; pass an empty `placeholder` to render none. The override applies to the standalone notes section header and the `NotesForm` field.

--- a/packages/react/src/components/checkout/__tests__/checkout-validation.test.tsx
+++ b/packages/react/src/components/checkout/__tests__/checkout-validation.test.tsx
@@ -75,6 +75,63 @@ describe('Checkout notes UI', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('uses the custom notes label and placeholder from the notes prop (standalone)', async () => {
+    renderCheckout({
+      sessionOverrides: {
+        enableNotesCollection: true,
+        enableShipping: false,
+        enableLocalPickup: false,
+      },
+      checkoutProps: {
+        notes: { label: 'Gift message', placeholder: 'Say something nice' },
+      },
+    });
+    await waitForCheckoutReady();
+
+    const notes = document.querySelector(
+      'textarea[name="notes"]'
+    ) as HTMLTextAreaElement;
+    expect(notes).toBeInTheDocument();
+    expect(notes).toHaveAttribute('placeholder', 'Say something nice');
+    expect(
+      screen.getByRole('heading', { name: 'Gift message' })
+    ).toBeInTheDocument();
+  });
+
+  it('renders no placeholder when notes.placeholder is an empty string', async () => {
+    renderCheckout({
+      sessionOverrides: {
+        enableNotesCollection: true,
+        enableShipping: false,
+        enableLocalPickup: false,
+      },
+      checkoutProps: { notes: { placeholder: '' } },
+    });
+    await waitForCheckoutReady();
+
+    const notes = document.querySelector(
+      'textarea[name="notes"]'
+    ) as HTMLTextAreaElement;
+    expect(notes).toHaveAttribute('placeholder', '');
+  });
+
+  it('falls back to localized notes label and placeholder without an override', async () => {
+    renderCheckout({
+      sessionOverrides: {
+        enableNotesCollection: true,
+        enableShipping: false,
+        enableLocalPickup: false,
+      },
+    });
+    await waitForCheckoutReady();
+
+    const notes = document.querySelector(
+      'textarea[name="notes"]'
+    ) as HTMLTextAreaElement;
+    expect(notes).toHaveAttribute('placeholder', 'Notes or special instructions');
+    expect(screen.getByRole('heading', { name: 'Notes' })).toBeInTheDocument();
+  });
+
   it('renders notes in both shipping and pickup flows', async () => {
     const { user } = renderCheckout();
     await waitForCheckoutReady();

--- a/packages/react/src/components/checkout/checkout.tsx
+++ b/packages/react/src/components/checkout/checkout.tsx
@@ -223,6 +223,15 @@ export interface CheckoutProps {
   defaultValues?: Pick<CheckoutFormData, 'contactEmail'>;
   isLoading?: boolean;
   loadingFallback?: ReactNode;
+  /**
+   * Overrides for the notes-collection field (rendered when the session has
+   * `enableNotesCollection`). Each falls back to localization when omitted;
+   * pass an empty `placeholder` to render no placeholder.
+   */
+  notes?: {
+    label?: string;
+    placeholder?: string;
+  };
 }
 
 export function Checkout(props: CheckoutProps) {

--- a/packages/react/src/components/checkout/form/checkout-form.tsx
+++ b/packages/react/src/components/checkout/form/checkout-form.tsx
@@ -483,7 +483,10 @@ export function CheckoutForm({
                           {session?.enableNotesCollection ? (
                             <>
                               <Target id='checkout.form.notes.before' />
-                              <NotesForm />
+                              <NotesForm
+                                label={props.notes?.label}
+                                placeholder={props.notes?.placeholder}
+                              />
                               <Target id='checkout.form.notes.after' />
                             </>
                           ) : null}
@@ -494,8 +497,13 @@ export function CheckoutForm({
                     {enableStandaloneNotes ? (
                       <CheckoutSection style={{ gridArea: 'notes' }}>
                         <Target id='checkout.form.notes.before' />
-                        <CheckoutSectionHeader title={t.general.notes} />
-                        <NotesForm />
+                        <CheckoutSectionHeader
+                          title={props.notes?.label ?? t.general.notes}
+                        />
+                        <NotesForm
+                          label={props.notes?.label}
+                          placeholder={props.notes?.placeholder}
+                        />
                         <Target id='checkout.form.notes.after' />
                       </CheckoutSection>
                     ) : null}

--- a/packages/react/src/components/checkout/notes/notes-form.tsx
+++ b/packages/react/src/components/checkout/notes/notes-form.tsx
@@ -17,7 +17,17 @@ import { useGoDaddyContext } from '@/godaddy-provider';
 import { eventIds } from '@/tracking/events';
 import { TrackingEventType, track } from '@/tracking/track';
 
-export function NotesForm() {
+export interface NotesFormProps {
+  /** Overrides the visually-hidden field label; falls back to `t.general.notes`. */
+  label?: string;
+  /**
+   * Overrides the textarea placeholder; falls back to
+   * `t.shipping.notesPlaceholder`. Pass an empty string for no placeholder.
+   */
+  placeholder?: string;
+}
+
+export function NotesForm({ label, placeholder }: NotesFormProps = {}) {
   const form = useFormContext();
   const { t } = useGoDaddyContext();
   const { isConfirmingCheckout, requiredFields } = useCheckoutContext();
@@ -78,9 +88,9 @@ export function NotesForm() {
         name='notes'
         render={({ field, fieldState }) => (
           <FormItem>
-            <FormLabel className='sr-only'>{t.general.notes}</FormLabel>
+            <FormLabel className='sr-only'>{label ?? t.general.notes}</FormLabel>
             <Textarea
-              placeholder={t.shipping.notesPlaceholder}
+              placeholder={placeholder ?? t.shipping.notesPlaceholder}
               {...field}
               hasError={!!fieldState.error}
               aria-required={requiredFields?.notes}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
The checkout notes-collection field renders a fixed label (`t.general.notes` → "Notes") and placeholder (`t.shipping.notesPlaceholder` → "Notes or special instructions"), both sourced from localization with no per-checkout override. Consumers that need a custom notes label/placeholder (e.g. pay links surfacing a merchant-configured notes title) had no clean way to set them — the only knobs were the global `localization` prop or `checkout.form.notes.*` target injection, which can't cleanly replace the section header or touch the placeholder.

**_TLDR: Support existing Notes feature for invoices and paylinks_**

## Changeset

<!--
Help reviewers and the release process by included a changeset entry.
Use `pnpm run changeset` and follow the prompts to create a changeset.
-->

- [x] Changeset added ([docs](https://github.com/godaddy/javascript#submit-a-changeset))

## Changes

- **`CheckoutProps`**: new optional `notes?: { label?: string; placeholder?: string }`.
- Threaded through `CheckoutForm` to both `<NotesForm />` render sites and the standalone notes section header.
- **`NotesForm`**: accepts optional `label` / `placeholder` props.
  - `label ?? t.general.notes`
  - `placeholder ?? t.shipping.notesPlaceholder`
  - Uses `??` (not `||`) so an explicit empty string renders **no** placeholder, while `undefined` keeps the localized default.
- Standalone notes section header title now resolves to `notes?.label ?? t.general.notes`.
- `CheckoutSectionHeader` is unchanged — it already accepts `title`.

## Backward compatibility

Fully backward compatible. When `notes` is omitted (or its fields are undefined), label and placeholder fall back to the existing localization strings — identical to current behavior. No other section is affected.

## Tests

Added cases to `checkout-validation.test.tsx` covering:
- custom `label` + `placeholder` render on the standalone notes field/header
- empty-string `placeholder` → no placeholder attribute
- omitted override → localized fallback ("Notes" / "Notes or special instructions")

All notes-UI tests pass (12/12).

## Usage

```tsx
<Checkout
  session={session}
  notes={{ label: "Gift message", placeholder: "" }} // "" => no placeholder
/>
```

## Test Plan

<img width="1115" height="745" alt="Screenshot 2026-07-21 at 11 10 06 AM" src="https://github.com/user-attachments/assets/df01ea21-3a27-4c8d-a57f-3ea31bad4e22" />

Data:

```
"payLink": {
        "checkoutUrlId": "6a88eb26-c217-4a68-9b1c-eb192a13052d",
        "urlType": "P",
        "title": "Basic Notes",
        "description": "this is the description area",
        "picture": "//isteam.test-wsimg.com/ip/54229bbe-db9b-4c69-bb2b-331c1916443e/efCo3JY.png",
        "amount": 10000,
        "currency": "USD",
        "isCustomPrice": false,
        "order": {},
        "metadata": {
            "notes": {
                "collectNotes": true,
                "isNotesRequired": false,
                "notesFieldTitle": "Notes"
            }
        }
    }
```

<img width="1839" height="964" alt="Screenshot 2026-07-21 at 2 10 14 PM" src="https://github.com/user-attachments/assets/15322890-f569-4149-97d7-c1b2a9b5ccdd" />

