### PR TITLE
Add VAT Included line item for inclusive taxes

### DIFF
--- a/.changeset/wet-plants-float.md
+++ b/.changeset/wet-plants-float.md
@@ -1,0 +1,6 @@
+---
+"@godaddy/localizations": patch
+"@godaddy/react": patch
+---
+
+Add line item for inclusive taxes during checkout

--- a/packages/localizations/src/deDe.ts
+++ b/packages/localizations/src/deDe.ts
@@ -168,6 +168,7 @@ export const deDe = {
     shipping: 'Versand',
     tip: 'Trinkgeld',
     estimatedTaxes: 'Geschätzte Steuern',
+    vatIncluded: 'MwSt. enthalten',
     fees: 'Gebühren',
     totalDue: 'Gesamtbetrag',
     orderSummary: 'Bestellübersicht',

--- a/packages/localizations/src/enAu.ts
+++ b/packages/localizations/src/enAu.ts
@@ -168,6 +168,7 @@ export const enAu = {
     shipping: 'Shipping',
     tip: 'Tip',
     estimatedTaxes: 'Estimated GST',
+    vatIncluded: 'GST Included',
     fees: 'Fees',
     totalDue: 'Total Due',
     orderSummary: 'Order Summary',

--- a/packages/localizations/src/enAu.ts
+++ b/packages/localizations/src/enAu.ts
@@ -168,7 +168,7 @@ export const enAu = {
     shipping: 'Shipping',
     tip: 'Tip',
     estimatedTaxes: 'Estimated GST',
-    vatIncluded: 'GST Included',
+    vatIncluded: 'GST included',
     fees: 'Fees',
     totalDue: 'Total Due',
     orderSummary: 'Order Summary',

--- a/packages/localizations/src/enIe.ts
+++ b/packages/localizations/src/enIe.ts
@@ -168,7 +168,7 @@ export const enIe = {
     shipping: 'Shipping',
     tip: 'Tip',
     estimatedTaxes: 'Estimated VAT',
-    vatIncluded: 'VAT Included',
+    vatIncluded: 'VAT included',
     fees: 'Fees',
     totalDue: 'Total Due',
     orderSummary: 'Order Summary',

--- a/packages/localizations/src/enIe.ts
+++ b/packages/localizations/src/enIe.ts
@@ -168,6 +168,7 @@ export const enIe = {
     shipping: 'Shipping',
     tip: 'Tip',
     estimatedTaxes: 'Estimated VAT',
+    vatIncluded: 'VAT Included',
     fees: 'Fees',
     totalDue: 'Total Due',
     orderSummary: 'Order Summary',

--- a/packages/localizations/src/enUs.ts
+++ b/packages/localizations/src/enUs.ts
@@ -168,7 +168,7 @@ export const enUs = {
     shipping: 'Shipping',
     tip: 'Tip',
     estimatedTaxes: 'Estimated taxes',
-    vatIncluded: 'VAT Included',
+    vatIncluded: 'VAT included',
     fees: 'Fees',
     totalDue: 'Total Due',
     orderSummary: 'Order Summary',

--- a/packages/localizations/src/enUs.ts
+++ b/packages/localizations/src/enUs.ts
@@ -168,6 +168,7 @@ export const enUs = {
     shipping: 'Shipping',
     tip: 'Tip',
     estimatedTaxes: 'Estimated taxes',
+    vatIncluded: 'VAT Included',
     fees: 'Fees',
     totalDue: 'Total Due',
     orderSummary: 'Order Summary',

--- a/packages/localizations/src/esAr.ts
+++ b/packages/localizations/src/esAr.ts
@@ -169,6 +169,7 @@ export const esAr = {
     shipping: 'Envío',
     tip: 'Propina',
     estimatedTaxes: 'Impuestos estimados',
+    vatIncluded: 'IVA incluido',
     fees: 'Cargos',
     totalDue: 'Total a Pagar',
     orderSummary: 'Resumen del Pedido',

--- a/packages/localizations/src/esCl.ts
+++ b/packages/localizations/src/esCl.ts
@@ -169,6 +169,7 @@ export const esCl = {
     shipping: 'Envío',
     tip: 'Propina',
     estimatedTaxes: 'Impuestos estimados',
+    vatIncluded: 'IVA incluido',
     fees: 'Cargos',
     totalDue: 'Total a Pagar',
     orderSummary: 'Resumen del Pedido',

--- a/packages/localizations/src/esCo.ts
+++ b/packages/localizations/src/esCo.ts
@@ -169,6 +169,7 @@ export const esCo = {
     shipping: 'Envío',
     tip: 'Propina',
     estimatedTaxes: 'Impuestos estimados',
+    vatIncluded: 'IVA incluido',
     fees: 'Cargos',
     totalDue: 'Total a pagar',
     orderSummary: 'Resumen del pedido',

--- a/packages/localizations/src/esEs.ts
+++ b/packages/localizations/src/esEs.ts
@@ -169,6 +169,7 @@ export const esEs = {
     shipping: 'Envío',
     tip: 'Propina',
     estimatedTaxes: 'Impuestos estimados',
+    vatIncluded: 'IVA incluido',
     fees: 'Cargos',
     totalDue: 'Total a pagar',
     orderSummary: 'Resumen del pedido',

--- a/packages/localizations/src/esMx.ts
+++ b/packages/localizations/src/esMx.ts
@@ -169,6 +169,7 @@ export const esMx = {
     shipping: 'Envío',
     tip: 'Propina',
     estimatedTaxes: 'Impuestos estimados',
+    vatIncluded: 'IVA incluido',
     fees: 'Cargos',
     totalDue: 'Total a Pagar',
     orderSummary: 'Resumen del Pedido',

--- a/packages/localizations/src/esPe.ts
+++ b/packages/localizations/src/esPe.ts
@@ -169,6 +169,7 @@ export const esPe = {
     shipping: 'Envío',
     tip: 'Propina',
     estimatedTaxes: 'Impuestos estimados',
+    vatIncluded: 'IVA incluido',
     fees: 'Cargos',
     totalDue: 'Total a Pagar',
     orderSummary: 'Resumen del Pedido',

--- a/packages/localizations/src/esUs.ts
+++ b/packages/localizations/src/esUs.ts
@@ -169,6 +169,7 @@ export const esUs = {
     shipping: 'Envío',
     tip: 'Propina',
     estimatedTaxes: 'Impuestos estimados',
+    vatIncluded: 'IVA incluido',
     fees: 'Cargos',
     totalDue: 'Total a Pagar',
     orderSummary: 'Resumen del Pedido',

--- a/packages/localizations/src/frCa.ts
+++ b/packages/localizations/src/frCa.ts
@@ -169,6 +169,7 @@ export const frCa = {
     shipping: 'Expédition',
     tip: 'Pourboire',
     estimatedTaxes: 'Taxes estimées',
+    vatIncluded: 'TVA incluse',
     fees: 'Frais',
     totalDue: 'Total à payer',
     orderSummary: 'Résumé de la commande',

--- a/packages/localizations/src/frFr.ts
+++ b/packages/localizations/src/frFr.ts
@@ -169,6 +169,7 @@ export const frFr = {
     shipping: 'Expédition',
     tip: 'Pourboire',
     estimatedTaxes: 'Taxes estimées',
+    vatIncluded: 'TVA incluse',
     fees: 'Frais',
     totalDue: 'Total à payer',
     orderSummary: 'Récapitulatif de la commande',

--- a/packages/localizations/src/idId.ts
+++ b/packages/localizations/src/idId.ts
@@ -168,6 +168,7 @@ export const idId = {
     shipping: 'Pengiriman',
     tip: 'Tip',
     estimatedTaxes: 'Perkiraan pajak',
+    vatIncluded: 'Termasuk PPN',
     fees: 'Biaya',
     totalDue: 'Total Pembayaran',
     orderSummary: 'Ringkasan Pesanan',

--- a/packages/localizations/src/itIt.ts
+++ b/packages/localizations/src/itIt.ts
@@ -169,6 +169,7 @@ export const itIt = {
     shipping: 'Spedizione',
     tip: 'Mancia',
     estimatedTaxes: 'Tasse stimate',
+    vatIncluded: 'IVA inclusa',
     fees: 'Commissioni',
     totalDue: 'Totale Dovuto',
     orderSummary: 'Riepilogo Ordine',

--- a/packages/localizations/src/ptBr.ts
+++ b/packages/localizations/src/ptBr.ts
@@ -168,6 +168,7 @@ export const ptBr = {
     shipping: 'Envio',
     tip: 'Gorjeta',
     estimatedTaxes: 'Impostos estimados',
+    vatIncluded: 'IVA incluído',
     fees: 'Taxas',
     totalDue: 'Total a Pagar',
     orderSummary: 'Resumo do Pedido',

--- a/packages/localizations/src/qaPs.ts
+++ b/packages/localizations/src/qaPs.ts
@@ -169,6 +169,7 @@ export const qaPs = {
     shipping: '[Šhîþþîñg Çöšţš]',
     tip: '[Ţîþ Âmöüñţ]',
     estimatedTaxes: '[Ëšţîmâţëd ţâxëš çâlçülâţîöñ]',
+    vatIncluded: '[VÂŢ Îñçlüdëd]',
     fees: '[Fëëš Çhârgëd]',
     totalDue: '[Tötâl Âmöüñţ Düë]',
     orderSummary: '[Ördër Šümmârÿ Dëţâîlš]',

--- a/packages/localizations/src/qaPs.ts
+++ b/packages/localizations/src/qaPs.ts
@@ -169,7 +169,7 @@ export const qaPs = {
     shipping: '[Šhîþþîñg Çöšţš]',
     tip: '[Ţîþ Âmöüñţ]',
     estimatedTaxes: '[Ëšţîmâţëd ţâxëš çâlçülâţîöñ]',
-    vatIncluded: '[VÂŢ Îñçlüdëd]',
+    vatIncluded: '[VÂŢ îñçlüdëd]',
     fees: '[Fëëš Çhârgëd]',
     totalDue: '[Tötâl Âmöüñţ Düë]',
     orderSummary: '[Ördër Šümmârÿ Dëţâîlš]',

--- a/packages/localizations/src/trTr.ts
+++ b/packages/localizations/src/trTr.ts
@@ -168,6 +168,7 @@ export const trTr = {
     shipping: 'Kargo',
     tip: 'Bahşiş',
     estimatedTaxes: 'Tahmini vergiler',
+    vatIncluded: 'KDV dahil',
     fees: 'Ücretler',
     totalDue: 'Ödenecek Toplam',
     orderSummary: 'Sipariş Özeti',

--- a/packages/localizations/src/viVn.ts
+++ b/packages/localizations/src/viVn.ts
@@ -168,6 +168,7 @@ export const viVn = {
     shipping: 'Vận chuyển',
     tip: 'Tip',
     estimatedTaxes: 'Thuế ước tính',
+    vatIncluded: 'Đã bao gồm VAT',
     fees: 'Phí',
     totalDue: 'Tổng cộng',
     orderSummary: 'Tóm tắt đơn hàng',

--- a/packages/localizations/src/zhCn.ts
+++ b/packages/localizations/src/zhCn.ts
@@ -163,6 +163,7 @@ export const zhCn = {
     shipping: '配送费',
     tip: '小费',
     estimatedTaxes: '预估税费',
+    vatIncluded: '已含增值税',
     fees: '费用',
     totalDue: '应付总计',
     orderSummary: '订单摘要',

--- a/packages/localizations/src/zhSg.ts
+++ b/packages/localizations/src/zhSg.ts
@@ -163,6 +163,7 @@ export const zhSg = {
     shipping: '运费',
     tip: '小费',
     estimatedTaxes: '预估税费',
+    vatIncluded: '已含消费税',
     fees: '费用',
     totalDue: '应付总额',
     orderSummary: '订单摘要',

--- a/packages/react/src/components/checkout/__tests__/checkout-layout-appearance.test.tsx
+++ b/packages/react/src/components/checkout/__tests__/checkout-layout-appearance.test.tsx
@@ -42,6 +42,7 @@ const targetSlots = [
   'checkout.summary.totals.shipping.before',
   'checkout.summary.totals.tip.before',
   'checkout.summary.totals.taxes.before',
+  'checkout.summary.totals.included-taxes.before',
   'checkout.summary.totals.fees.before',
   'checkout.summary.totals.after',
   'checkout.summary.totals.total-due.before',

--- a/packages/react/src/components/checkout/__tests__/checkout-totals-summary.test.tsx
+++ b/packages/react/src/components/checkout/__tests__/checkout-totals-summary.test.tsx
@@ -66,6 +66,47 @@ describe('Checkout totals and order summary UI', () => {
     expect(document.body).toHaveTextContent(/estimated taxes/i);
     expect(document.body).toHaveTextContent(/fees/i);
     expect(document.body).toHaveTextContent(/total due/i);
+    expect(document.body).not.toHaveTextContent(/vat included/i);
+  });
+
+  it('renders the total of included tax constituents separately from additive taxes', async () => {
+    renderCheckout({
+      draftOrderOverrides: {
+        totals: totals({
+          taxTotal: { value: 456, currencyCode: 'USD' },
+        }),
+        taxes: [
+          {
+            id: 'included-tax-1',
+            name: 'VAT',
+            included: true,
+            exempted: false,
+            ratePercentage: '2.5',
+            amount: { value: 100, currencyCode: 'USD' },
+          },
+          {
+            id: 'additive-tax',
+            name: 'Sales tax',
+            included: false,
+            exempted: false,
+            ratePercentage: '5',
+            amount: { value: 456, currencyCode: 'USD' },
+          },
+          {
+            id: 'included-tax-2',
+            name: 'VAT surcharge',
+            included: true,
+            exempted: false,
+            ratePercentage: '0.5',
+            amount: { value: 23, currencyCode: 'USD' },
+          },
+        ],
+      },
+    });
+    await waitForCheckoutReady();
+
+    expect(document.body).toHaveTextContent(/vat included/i);
+    expect(screen.getAllByText('$1.23').length).toBeGreaterThan(0);
   });
 
   it('renders loading skeleton rows for in-flight discount, shipping, tax, and fee mutations', async () => {

--- a/packages/react/src/components/checkout/__tests__/checkout-totals-summary.test.tsx
+++ b/packages/react/src/components/checkout/__tests__/checkout-totals-summary.test.tsx
@@ -1,7 +1,10 @@
 import { act, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { useUpdateTaxes } from '@/components/checkout/order/use-update-taxes';
 import { checkoutMutationKeys } from '@/components/checkout/utils/query-keys';
+import { getDraftOrder, updateDraftOrderTaxes } from '@/lib/godaddy/godaddy';
 import {
+  buildDraftOrder,
   buildLineItem,
   renderCheckout,
   setFeeTotal,
@@ -106,8 +109,185 @@ describe('Checkout totals and order summary UI', () => {
     await waitForCheckoutReady();
 
     expect(document.body).toHaveTextContent(/vat included/i);
-    expect(screen.getAllByText('$1.23').length).toBeGreaterThan(0);
+    for (const label of screen.getAllByText(/vat included/i)) {
+      expect(label.closest('.flex.justify-between')).toHaveTextContent('$1.23');
+    }
   });
+
+  it('hides included taxes when tax display is disabled', async () => {
+    renderCheckout({
+      sessionOverrides: { enableTaxCollection: false },
+      draftOrderOverrides: {
+        totals: totals({ taxTotal: { value: 0, currencyCode: 'USD' } }),
+        taxes: [
+          { included: true, amount: { value: 123, currencyCode: 'USD' } },
+        ],
+      },
+    });
+    await waitForCheckoutReady();
+
+    expect(document.body).not.toHaveTextContent(
+      /estimated taxes|vat included/i
+    );
+  });
+
+  it.each([
+    { included: false, amount: 123 },
+    { included: true, amount: 0 },
+  ])(
+    'hides the included-tax row for $included / $amount',
+    async ({ included, amount }) => {
+      renderCheckout({
+        draftOrderOverrides: {
+          taxes: [{ included, amount: { value: amount, currencyCode: 'USD' } }],
+        },
+      });
+      await waitForCheckoutReady();
+
+      expect(document.body).not.toHaveTextContent(/vat included/i);
+    }
+  );
+
+  it.each([
+    'applyDiscount',
+    'applyShippingMethod',
+    'removeShippingMethod',
+  ] as const)(
+    'hides the previous included-tax amount during %s',
+    async mutation => {
+      const { queryClient, session } = renderCheckout({
+        draftOrderOverrides: {
+          taxes: [
+            { included: true, amount: { value: 123, currencyCode: 'USD' } },
+          ],
+        },
+      });
+      await waitForCheckoutReady();
+      await waitFor(() => expect(queryClient.isMutating()).toBe(0));
+
+      let finishMutation!: () => void;
+      const execution = queryClient
+        .getMutationCache()
+        .build(queryClient, {
+          mutationKey: checkoutMutationKeys[mutation](session.id),
+          mutationFn: () =>
+            new Promise<void>(resolve => {
+              finishMutation = resolve;
+            }),
+        })
+        .execute(undefined);
+
+      await waitFor(() => {
+        for (const label of screen.getAllByText(/vat included/i)) {
+          const row = label.closest('.flex.justify-between');
+          expect(row?.querySelector('.animate-pulse')).toBeInTheDocument();
+          expect(row).not.toHaveTextContent('$1.23');
+        }
+      });
+
+      await act(async () => {
+        finishMutation();
+        await execution;
+      });
+      await waitFor(() => {
+        for (const label of screen.getAllByText(/vat included/i)) {
+          expect(label.closest('.flex.justify-between')).toHaveTextContent(
+            '$1.23'
+          );
+        }
+      });
+    }
+  );
+
+  it.each([50, 0])(
+    'keeps tax loading until a refetch returns included taxes of %i',
+    async amount => {
+      function UpdateTaxesButton() {
+        const mutation = useUpdateTaxes();
+        return (
+          <button type='button' onClick={() => mutation.mutate(undefined)}>
+            Recalculate taxes
+          </button>
+        );
+      }
+
+      const { queryClient, session, draftOrder, user } = renderCheckout({
+        draftOrderOverrides: {
+          taxes: [
+            { included: true, amount: { value: 123, currencyCode: 'USD' } },
+          ],
+        },
+        checkoutProps: {
+          targets: { 'checkout.form.before': () => <UpdateTaxesButton /> },
+        },
+      });
+      await waitForCheckoutReady();
+      await waitFor(() => {
+        expect(queryClient.isMutating()).toBe(0);
+        expect(queryClient.isFetching()).toBe(0);
+      });
+
+      let finishRefetch!: () => void;
+      const refetchGate = new Promise<void>(resolve => {
+        finishRefetch = resolve;
+      });
+      vi.mocked(updateDraftOrderTaxes).mockResolvedValueOnce({
+        calculateCheckoutSessionTaxes: {
+          totalTaxAmount: { value: 0, currencyCode: 'USD' },
+        },
+      });
+      vi.mocked(getDraftOrder).mockImplementationOnce(async () => {
+        await refetchGate;
+        return {
+          checkoutSession: {
+            ...session,
+            draftOrder: buildDraftOrder({
+              ...draftOrder,
+              taxes:
+                amount > 0
+                  ? [
+                      {
+                        included: true,
+                        amount: { value: amount, currencyCode: 'USD' },
+                      },
+                    ]
+                  : [],
+              totals: totals({ taxTotal: { value: 0, currencyCode: 'USD' } }),
+            }),
+          },
+        };
+      });
+
+      await user.click(
+        screen.getByRole('button', { name: 'Recalculate taxes' })
+      );
+      await waitFor(() => expect(queryClient.isFetching()).toBeGreaterThan(0));
+      expect(
+        queryClient.isMutating({
+          mutationKey: checkoutMutationKeys.updateDraftOrderTaxes(session.id),
+        })
+      ).toBe(1);
+      for (const label of screen.getAllByText(/vat included/i)) {
+        const row = label.closest('.flex.justify-between');
+        expect(row?.querySelector('.animate-pulse')).toBeInTheDocument();
+        expect(row).not.toHaveTextContent('$1.23');
+      }
+
+      await act(async () => {
+        finishRefetch();
+      });
+      await waitFor(() => expect(queryClient.isMutating()).toBe(0));
+      if (amount > 0) {
+        for (const label of screen.getAllByText(/vat included/i)) {
+          const row = label.closest('.flex.justify-between');
+          expect(row).toHaveTextContent('$0.50');
+          expect(row?.querySelector('.animate-pulse')).not.toBeInTheDocument();
+        }
+      } else {
+        expect(document.body).not.toHaveTextContent(/vat included/i);
+      }
+    }
+  );
 
   it('renders loading skeleton rows for in-flight discount, shipping, tax, and fee mutations', async () => {
     const { queryClient, session } = renderCheckout({

--- a/packages/react/src/components/checkout/form/checkout-form.tsx
+++ b/packages/react/src/components/checkout/form/checkout-form.tsx
@@ -25,7 +25,10 @@ import {
 import { NotesForm } from '@/components/checkout/notes/notes-form';
 import { DraftOrderSyncProvider } from '@/components/checkout/order/draft-order-sync-provider';
 import { isFreeOrderTotal } from '@/components/checkout/order/is-free-order';
-import { useDraftOrderTotals } from '@/components/checkout/order/use-draft-order';
+import {
+  useDraftOrderIncludedTaxTotal,
+  useDraftOrderTotals,
+} from '@/components/checkout/order/use-draft-order';
 import { BillingPolicyTransitionController } from '@/components/checkout/payment/billing-policy-transition-controller';
 import { PaymentForm } from '@/components/checkout/payment/payment-form';
 import {
@@ -200,6 +203,7 @@ export function CheckoutForm({
   }, [dirtyFields, form, formValues, isCheckoutBusy]);
 
   const draftOrderTotalsQuery = useDraftOrderTotals();
+  const { data: vatIncluded = 0 } = useDraftOrderIncludedTaxTotal();
 
   const { data: totals, isLoading: totalsLoading } = draftOrderTotalsQuery;
   validationContextRef.current.totals = totals;
@@ -551,6 +555,7 @@ export function CheckoutForm({
                                 currencyCode={currencyCode}
                                 tip={tipTotal}
                                 taxes={taxTotal}
+                                vatIncluded={vatIncluded}
                                 fees={feeTotal}
                                 isTaxLoading={isUpdatingTaxes}
                                 isFeeLoading={isUpdatingFees}
@@ -622,6 +627,7 @@ export function CheckoutForm({
                             currencyCode={currencyCode}
                             tip={tipTotal}
                             taxes={taxTotal}
+                            vatIncluded={vatIncluded}
                             fees={feeTotal}
                             isTaxLoading={isUpdatingTaxes}
                             isFeeLoading={isUpdatingFees}
@@ -656,6 +662,7 @@ export function CheckoutForm({
                     currencyCode={currencyCode}
                     tip={tipTotal}
                     taxes={taxTotal}
+                    vatIncluded={vatIncluded}
                     fees={feeTotal}
                     isTaxLoading={isUpdatingTaxes}
                     isFeeLoading={isUpdatingFees}

--- a/packages/react/src/components/checkout/form/checkout-form.tsx
+++ b/packages/react/src/components/checkout/form/checkout-form.tsx
@@ -157,6 +157,11 @@ export function CheckoutForm({
   const tipAmount = form.watch('tipAmount');
   const isPickup = deliveryMethod === DeliveryMethods.PICKUP;
   const isShipping = deliveryMethod === DeliveryMethods.SHIP;
+  const isRemovingShipping =
+    useIsMutating({
+      mutationKey: checkoutMutationKeys.removeShippingMethod(session?.id),
+    }) > 0;
+
   const isUpdatingShipping =
     useIsMutating({
       mutationKey: checkoutMutationKeys.applyShippingMethod(session?.id),
@@ -203,7 +208,7 @@ export function CheckoutForm({
   }, [dirtyFields, form, formValues, isCheckoutBusy]);
 
   const draftOrderTotalsQuery = useDraftOrderTotals();
-  const { data: vatIncluded = 0 } = useDraftOrderIncludedTaxTotal();
+  const { data: includedTaxTotal = 0 } = useDraftOrderIncludedTaxTotal();
 
   const { data: totals, isLoading: totalsLoading } = draftOrderTotalsQuery;
   validationContextRef.current.totals = totals;
@@ -555,11 +560,13 @@ export function CheckoutForm({
                                 currencyCode={currencyCode}
                                 tip={tipTotal}
                                 taxes={taxTotal}
-                                vatIncluded={vatIncluded}
+                                includedTaxTotal={includedTaxTotal}
                                 fees={feeTotal}
                                 isTaxLoading={isUpdatingTaxes}
                                 isFeeLoading={isUpdatingFees}
-                                isShippingLoading={isUpdatingShipping}
+                                isShippingLoading={
+                                  isUpdatingShipping || isRemovingShipping
+                                }
                                 isDiscountLoading={isDiscountApplying}
                                 subtotal={subtotal}
                                 discount={orderDiscount}
@@ -627,11 +634,13 @@ export function CheckoutForm({
                             currencyCode={currencyCode}
                             tip={tipTotal}
                             taxes={taxTotal}
-                            vatIncluded={vatIncluded}
+                            includedTaxTotal={includedTaxTotal}
                             fees={feeTotal}
                             isTaxLoading={isUpdatingTaxes}
                             isFeeLoading={isUpdatingFees}
-                            isShippingLoading={isUpdatingShipping}
+                            isShippingLoading={
+                              isUpdatingShipping || isRemovingShipping
+                            }
                             subtotal={subtotal}
                             discount={orderDiscount}
                             isDiscountLoading={isDiscountApplying}
@@ -662,11 +671,11 @@ export function CheckoutForm({
                     currencyCode={currencyCode}
                     tip={tipTotal}
                     taxes={taxTotal}
-                    vatIncluded={vatIncluded}
+                    includedTaxTotal={includedTaxTotal}
                     fees={feeTotal}
                     isTaxLoading={isUpdatingTaxes}
                     isFeeLoading={isUpdatingFees}
-                    isShippingLoading={isUpdatingShipping}
+                    isShippingLoading={isUpdatingShipping || isRemovingShipping}
                     subtotal={subtotal}
                     discount={orderDiscount}
                     isDiscountLoading={isDiscountApplying}

--- a/packages/react/src/components/checkout/order/use-draft-order.ts
+++ b/packages/react/src/components/checkout/order/use-draft-order.ts
@@ -1,5 +1,6 @@
 import { type UseQueryResult, useQuery } from '@tanstack/react-query';
 import { useCheckoutContext } from '@/components/checkout/checkout';
+import { getIncludedTaxTotal } from '@/components/checkout/totals/utils/get-included-tax-total';
 import { checkoutQueryKeys } from '@/components/checkout/utils/query-keys';
 import { useGoDaddyContext } from '@/godaddy-provider';
 import { getDraftOrder } from '@/lib/godaddy/godaddy';
@@ -59,6 +60,14 @@ export function useDraftOrderShippingAddress() {
 export function useDraftOrderTotals() {
   return useDraftOrder<Totals | null>(
     data => data.checkoutSession?.draftOrder?.totals ?? null,
+    'draft-order'
+  );
+}
+
+export function useDraftOrderIncludedTaxTotal() {
+  return useDraftOrder<number>(
+    data =>
+      getIncludedTaxTotal(data.checkoutSession?.draftOrder?.taxes ?? null),
     'draft-order'
   );
 }

--- a/packages/react/src/components/checkout/order/use-draft-order.ts
+++ b/packages/react/src/components/checkout/order/use-draft-order.ts
@@ -66,8 +66,7 @@ export function useDraftOrderTotals() {
 
 export function useDraftOrderIncludedTaxTotal() {
   return useDraftOrder<number>(
-    data =>
-      getIncludedTaxTotal(data.checkoutSession?.draftOrder?.taxes ?? null),
+    data => getIncludedTaxTotal(data.checkoutSession?.draftOrder?.taxes),
     'draft-order'
   );
 }

--- a/packages/react/src/components/checkout/order/use-update-taxes.ts
+++ b/packages/react/src/components/checkout/order/use-update-taxes.ts
@@ -1,12 +1,10 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import type { ResultOf } from 'gql.tada';
 import { useCheckoutContext } from '@/components/checkout/checkout';
 import {
   checkoutMutationKeys,
   checkoutQueryKeys,
 } from '@/components/checkout/utils/query-keys';
 import { useGoDaddyContext } from '@/godaddy-provider';
-import type { DraftOrderQuery } from '@/lib/godaddy/checkout-queries.ts';
 import { updateDraftOrderTaxes } from '@/lib/godaddy/godaddy';
 
 export function useUpdateTaxes() {
@@ -35,40 +33,10 @@ export function useUpdateTaxes() {
         : await updateDraftOrderTaxes(session, destination, apiHost);
       return data;
     },
-    onSuccess: data => {
-      if (!session) return;
-
-      // Extract shippingTotal from mutation response
-      const taxesTotal = data?.calculateCheckoutSessionTaxes?.totalTaxAmount;
-
-      // Update the cached draft-order query (includes totals)
-      if (taxesTotal) {
-        queryClient.setQueryData(
-          checkoutQueryKeys.draftOrder(session.id),
-          (old: ResultOf<typeof DraftOrderQuery> | undefined) => {
-            if (!old) return old;
-            return {
-              ...old,
-              checkoutSession: {
-                ...old.checkoutSession,
-                draftOrder: {
-                  ...old?.checkoutSession?.draftOrder,
-                  totals: {
-                    ...old?.checkoutSession?.draftOrder?.totals,
-                    taxesTotal: {
-                      ...taxesTotal,
-                    },
-                  },
-                },
-              },
-            };
-          }
-        );
-      }
-    },
     onSettled: () => {
       if (!session) return;
-      queryClient.invalidateQueries({
+      // Keep the mutation pending until totals and tax constituents refresh together.
+      return queryClient.invalidateQueries({
         queryKey: checkoutQueryKeys.draftOrder(session.id),
       });
     },

--- a/packages/react/src/components/checkout/payment/payment-form.tsx
+++ b/packages/react/src/components/checkout/payment/payment-form.tsx
@@ -596,6 +596,7 @@ export function PaymentForm(
             currencyCode={props.currencyCode}
             tip={props.tip}
             taxes={props.taxes}
+            vatIncluded={props.vatIncluded}
             fees={props.fees}
             isTaxLoading={props.isTaxLoading}
             isFeeLoading={props.isFeeLoading}

--- a/packages/react/src/components/checkout/payment/payment-form.tsx
+++ b/packages/react/src/components/checkout/payment/payment-form.tsx
@@ -596,11 +596,12 @@ export function PaymentForm(
             currencyCode={props.currencyCode}
             tip={props.tip}
             taxes={props.taxes}
-            vatIncluded={props.vatIncluded}
+            includedTaxTotal={props.includedTaxTotal}
             fees={props.fees}
             isTaxLoading={props.isTaxLoading}
             isFeeLoading={props.isFeeLoading}
             isShippingLoading={props.isShippingLoading}
+            isDiscountLoading={props.isDiscountLoading}
             subtotal={props.subtotal}
             discount={props.discount}
             shipping={props.shipping}

--- a/packages/react/src/components/checkout/target/types.ts
+++ b/packages/react/src/components/checkout/target/types.ts
@@ -30,6 +30,7 @@ export const checkoutTargetIds = [
   'checkout.summary.totals.shipping.before',
   'checkout.summary.totals.tip.before',
   'checkout.summary.totals.taxes.before',
+  'checkout.summary.totals.included-taxes.before',
   'checkout.summary.totals.fees.before',
   'checkout.summary.totals.total-due.before',
   'checkout.summary.totals.total-due.after',

--- a/packages/react/src/components/checkout/totals/totals.tsx
+++ b/packages/react/src/components/checkout/totals/totals.tsx
@@ -17,6 +17,7 @@ export interface DraftOrderTotalsProps {
   total?: number;
   tip?: number;
   taxes?: number;
+  vatIncluded?: number;
   isTaxLoading?: boolean;
   fees?: number;
   isFeeLoading?: boolean;
@@ -72,6 +73,7 @@ export function DraftOrderTotals({
   total = 0,
   tip = 0,
   taxes = 0,
+  vatIncluded = 0,
   fees = 0,
   enableDiscounts = false,
   enableTaxes = false,
@@ -155,6 +157,18 @@ export function DraftOrderTotals({
               inputInMinorUnits={inputInMinorUnits}
             />
           ))}
+        {vatIncluded > 0 ? (
+          isTaxLoading ? (
+            <TotalLineItemSkeleton title={t.totals.vatIncluded} />
+          ) : (
+            <TotalLineItem
+              currencyCode={currencyCode}
+              title={t.totals.vatIncluded}
+              value={vatIncluded}
+              inputInMinorUnits={inputInMinorUnits}
+            />
+          )
+        ) : null}
         <Target id='checkout.summary.totals.fees.before' />
         {enableFees &&
           (isFeeLoading ? (

--- a/packages/react/src/components/checkout/totals/totals.tsx
+++ b/packages/react/src/components/checkout/totals/totals.tsx
@@ -17,7 +17,7 @@ export interface DraftOrderTotalsProps {
   total?: number;
   tip?: number;
   taxes?: number;
-  vatIncluded?: number;
+  includedTaxTotal?: number;
   isTaxLoading?: boolean;
   fees?: number;
   isFeeLoading?: boolean;
@@ -73,7 +73,7 @@ export function DraftOrderTotals({
   total = 0,
   tip = 0,
   taxes = 0,
-  vatIncluded = 0,
+  includedTaxTotal = 0,
   fees = 0,
   enableDiscounts = false,
   enableTaxes = false,
@@ -157,14 +157,15 @@ export function DraftOrderTotals({
               inputInMinorUnits={inputInMinorUnits}
             />
           ))}
-        {vatIncluded > 0 ? (
-          isTaxLoading ? (
+        <Target id='checkout.summary.totals.included-taxes.before' />
+        {enableTaxes && includedTaxTotal > 0 ? (
+          isTaxLoading || isShippingLoading || isDiscountLoading ? (
             <TotalLineItemSkeleton title={t.totals.vatIncluded} />
           ) : (
             <TotalLineItem
               currencyCode={currencyCode}
               title={t.totals.vatIncluded}
-              value={vatIncluded}
+              value={includedTaxTotal}
               inputInMinorUnits={inputInMinorUnits}
             />
           )

--- a/packages/react/src/components/checkout/totals/utils/get-included-tax-total.test.ts
+++ b/packages/react/src/components/checkout/totals/utils/get-included-tax-total.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { getIncludedTaxTotal } from './get-included-tax-total';
+
+describe('getIncludedTaxTotal', () => {
+  it('totals only included tax constituents', () => {
+    expect(
+      getIncludedTaxTotal([
+        { included: true, additional: false, amount: { value: 125 } },
+        { included: false, additional: true, amount: { value: 300 } },
+        { included: true, additional: null, amount: { value: 75 } },
+        { included: true, additional: true, amount: { value: 500 } },
+      ])
+    ).toBe(200);
+  });
+
+  it('returns zero when included taxes have no positive amount', () => {
+    expect(getIncludedTaxTotal()).toBe(0);
+    expect(getIncludedTaxTotal([{ included: true, amount: null }])).toBe(0);
+  });
+});

--- a/packages/react/src/components/checkout/totals/utils/get-included-tax-total.test.ts
+++ b/packages/react/src/components/checkout/totals/utils/get-included-tax-total.test.ts
@@ -5,10 +5,10 @@ describe('getIncludedTaxTotal', () => {
   it('totals only included tax constituents', () => {
     expect(
       getIncludedTaxTotal([
-        { included: true, additional: false, amount: { value: 125 } },
-        { included: false, additional: true, amount: { value: 300 } },
-        { included: true, additional: null, amount: { value: 75 } },
-        { included: true, additional: true, amount: { value: 500 } },
+        { included: true, amount: { value: 125 } },
+        { included: false, amount: { value: 300 } },
+        { included: true, amount: { value: 75 } },
+        { included: null, amount: { value: 500 } },
       ])
     ).toBe(200);
   });

--- a/packages/react/src/components/checkout/totals/utils/get-included-tax-total.ts
+++ b/packages/react/src/components/checkout/totals/utils/get-included-tax-total.ts
@@ -1,0 +1,20 @@
+interface TaxAmount {
+  included?: boolean | null;
+  additional?: boolean | null;
+  amount?: {
+    value?: number | null;
+  } | null;
+}
+
+export function getIncludedTaxTotal(
+  taxes?: readonly TaxAmount[] | null
+): number {
+  return (
+    taxes?.reduce(
+      (total, tax) =>
+        total +
+        (tax.included && tax.additional !== true ? tax.amount?.value || 0 : 0),
+      0
+    ) ?? 0
+  );
+}

--- a/packages/react/src/components/checkout/totals/utils/get-included-tax-total.ts
+++ b/packages/react/src/components/checkout/totals/utils/get-included-tax-total.ts
@@ -1,6 +1,5 @@
 interface TaxAmount {
   included?: boolean | null;
-  additional?: boolean | null;
   amount?: {
     value?: number | null;
   } | null;
@@ -12,8 +11,7 @@ export function getIncludedTaxTotal(
   return (
     taxes?.reduce(
       (total, tax) =>
-        total +
-        (tax.included && tax.additional !== true ? tax.amount?.value || 0 : 0),
+        total + (tax.included === true ? tax.amount?.value || 0 : 0),
       0
     ) ?? 0
   );

--- a/packages/react/src/components/storefront/cart.tsx
+++ b/packages/react/src/components/storefront/cart.tsx
@@ -3,6 +3,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Loader2, ShoppingCart } from 'lucide-react';
 import type { Product } from '@/components/checkout/line-items/line-items';
+import { getIncludedTaxTotal } from '@/components/checkout/totals/utils/get-included-tax-total';
 import { CartLineItems } from '@/components/storefront/cart-line-items';
 import { CartTotals } from '@/components/storefront/cart-totals';
 import { Button } from '@/components/ui/button';
@@ -110,6 +111,7 @@ export function Cart({
   const subtotal = order?.totals?.subTotal?.value || 0;
   const shipping = order?.totals?.shippingTotal?.value || 0;
   const taxes = order?.totals?.taxTotal?.value || 0;
+  const vatIncluded = getIncludedTaxTotal(order?.taxes);
   const discount = order?.totals?.discountTotal?.value || 0;
   const total = order?.totals?.total?.value || 0;
 
@@ -122,6 +124,7 @@ export function Cart({
     total,
     tip: 0,
     taxes,
+    vatIncluded,
     enableDiscounts: false,
     enableTaxes: true,
     isTaxLoading: false,

--- a/packages/react/src/components/storefront/cart.tsx
+++ b/packages/react/src/components/storefront/cart.tsx
@@ -111,7 +111,7 @@ export function Cart({
   const subtotal = order?.totals?.subTotal?.value || 0;
   const shipping = order?.totals?.shippingTotal?.value || 0;
   const taxes = order?.totals?.taxTotal?.value || 0;
-  const vatIncluded = getIncludedTaxTotal(order?.taxes);
+  const includedTaxTotal = getIncludedTaxTotal(order?.taxes);
   const discount = order?.totals?.discountTotal?.value || 0;
   const total = order?.totals?.total?.value || 0;
 
@@ -124,7 +124,7 @@ export function Cart({
     total,
     tip: 0,
     taxes,
-    vatIncluded,
+    includedTaxTotal,
     enableDiscounts: false,
     enableTaxes: true,
     isTaxLoading: false,

--- a/packages/react/src/lib/godaddy/checkout-env.ts
+++ b/packages/react/src/lib/godaddy/checkout-env.ts
@@ -2140,6 +2140,15 @@ const introspection = {
             "isDeprecated": false
           },
           {
+            "name": "tips",
+            "type": {
+              "kind": "OBJECT",
+              "name": "CheckoutSessionTips"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
             "name": "token",
             "type": {
               "kind": "SCALAR",
@@ -2969,6 +2978,80 @@ const introspection = {
           }
         ],
         "isOneOf": false
+      },
+      {
+        "kind": "OBJECT",
+        "name": "CheckoutSessionFee",
+        "fields": [
+          {
+            "name": "amount",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "feeProgramId",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "feeProgramType",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "feeType",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "signature",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "OBJECT",
+        "name": "CheckoutSessionFeesResult",
+        "fields": [
+          {
+            "name": "fees",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CheckoutSessionFee"
+                }
+              }
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
       },
       {
         "kind": "OBJECT",
@@ -3994,6 +4077,242 @@ const introspection = {
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "CheckoutSessionAddressInput"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "OBJECT",
+        "name": "CheckoutSessionTips",
+        "fields": [
+          {
+            "name": "default",
+            "type": {
+              "kind": "OBJECT",
+              "name": "CheckoutSessionTipsDefault"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "thresholds",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CheckoutSessionTipsThreshold"
+                }
+              }
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "OBJECT",
+        "name": "CheckoutSessionTipsDefault",
+        "fields": [
+          {
+            "name": "amounts",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              }
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "percentages",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              }
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "CheckoutSessionTipsDefaultInput",
+        "inputFields": [
+          {
+            "name": "amounts",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              }
+            }
+          },
+          {
+            "name": "percentages",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              }
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "CheckoutSessionTipsInput",
+        "inputFields": [
+          {
+            "name": "default",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "CheckoutSessionTipsDefaultInput"
+            }
+          },
+          {
+            "name": "thresholds",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "CheckoutSessionTipsThresholdInput"
+                }
+              }
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "OBJECT",
+        "name": "CheckoutSessionTipsThreshold",
+        "fields": [
+          {
+            "name": "amounts",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              }
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "maxSubtotal",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "minSubtotal",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "percentages",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              }
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "CheckoutSessionTipsThresholdInput",
+        "inputFields": [
+          {
+            "name": "amounts",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              }
+            }
+          },
+          {
+            "name": "maxSubtotal",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int"
+              }
+            }
+          },
+          {
+            "name": "minSubtotal",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int"
+              }
+            }
+          },
+          {
+            "name": "percentages",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              }
             }
           }
         ],
@@ -6335,6 +6654,46 @@ const introspection = {
         "isOneOf": false
       },
       {
+        "kind": "ENUM",
+        "name": "FeeProgramType",
+        "enumValues": [
+          {
+            "name": "CASH_DISCOUNT",
+            "isDeprecated": false
+          },
+          {
+            "name": "CONVENIENCE_FEE",
+            "isDeprecated": false
+          },
+          {
+            "name": "SERVICE_FEE",
+            "isDeprecated": false
+          },
+          {
+            "name": "SURCHARGE",
+            "isDeprecated": false
+          }
+        ]
+      },
+      {
+        "kind": "ENUM",
+        "name": "FeeType",
+        "enumValues": [
+          {
+            "name": "FIXED",
+            "isDeprecated": false
+          },
+          {
+            "name": "HYBRID",
+            "isDeprecated": false
+          },
+          {
+            "name": "PERCENTAGE",
+            "isDeprecated": false
+          }
+        ]
+      },
+      {
         "kind": "SCALAR",
         "name": "Float"
       },
@@ -6404,6 +6763,24 @@ const introspection = {
           },
           {
             "name": "TO_GO",
+            "isDeprecated": false
+          }
+        ]
+      },
+      {
+        "kind": "ENUM",
+        "name": "FundingSourceType",
+        "enumValues": [
+          {
+            "name": "CREDIT",
+            "isDeprecated": false
+          },
+          {
+            "name": "DEBIT",
+            "isDeprecated": false
+          },
+          {
+            "name": "PREPAID",
             "isDeprecated": false
           }
         ]
@@ -7398,6 +7775,26 @@ const introspection = {
             "isDeprecated": false
           },
           {
+            "name": "calculateCheckoutSessionFees",
+            "type": {
+              "kind": "OBJECT",
+              "name": "CheckoutSessionFeesResult"
+            },
+            "args": [
+              {
+                "name": "fundingSourceType",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "FundingSourceType"
+                  }
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
             "name": "calculateCheckoutSessionTaxes",
             "type": {
               "kind": "OBJECT",
@@ -7681,6 +8078,19 @@ const introspection = {
         "name": "MutationAuthorizeCheckoutSessionInput",
         "inputFields": [
           {
+            "name": "fees",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "TransactionFeeInput"
+                }
+              }
+            }
+          },
+          {
             "name": "paymentProvider",
             "type": {
               "kind": "NON_NULL",
@@ -7705,6 +8115,13 @@ const introspection = {
                 "kind": "SCALAR",
                 "name": "String"
               }
+            }
+          },
+          {
+            "name": "tipAmount",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
             }
           }
         ],
@@ -7733,6 +8150,19 @@ const introspection = {
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "CalculatedTaxesInput"
+            }
+          },
+          {
+            "name": "fees",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "TransactionFeeInput"
+                }
+              }
             }
           },
           {
@@ -7818,6 +8248,13 @@ const introspection = {
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "MoneyInput"
+            }
+          },
+          {
+            "name": "tipAmount",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
             }
           }
         ],
@@ -8089,6 +8526,13 @@ const introspection = {
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "CheckoutSessionTaxesOptionsInput"
+            }
+          },
+          {
+            "name": "tips",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "CheckoutSessionTipsInput"
             }
           },
           {
@@ -8521,6 +8965,13 @@ const introspection = {
             "type": {
               "kind": "SCALAR",
               "name": "String"
+            }
+          },
+          {
+            "name": "tips",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "CheckoutSessionTipsInput"
             }
           },
           {
@@ -10843,6 +11294,57 @@ const introspection = {
           }
         ],
         "interfaces": []
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "TransactionFeeInput",
+        "inputFields": [
+          {
+            "name": "amount",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int"
+              }
+            }
+          },
+          {
+            "name": "feeProgramType",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "ENUM",
+                "name": "FeeProgramType"
+              }
+            }
+          },
+          {
+            "name": "feeType",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "ENUM",
+                "name": "FeeType"
+              }
+            }
+          },
+          {
+            "name": "required",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean"
+            }
+          },
+          {
+            "name": "signature",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          }
+        ],
+        "isOneOf": false
       },
       {
         "kind": "OBJECT",

--- a/packages/react/src/lib/godaddy/checkout-env.ts
+++ b/packages/react/src/lib/godaddy/checkout-env.ts
@@ -2140,15 +2140,6 @@ const introspection = {
             "isDeprecated": false
           },
           {
-            "name": "tips",
-            "type": {
-              "kind": "OBJECT",
-              "name": "CheckoutSessionTips"
-            },
-            "args": [],
-            "isDeprecated": false
-          },
-          {
             "name": "token",
             "type": {
               "kind": "SCALAR",
@@ -2978,80 +2969,6 @@ const introspection = {
           }
         ],
         "isOneOf": false
-      },
-      {
-        "kind": "OBJECT",
-        "name": "CheckoutSessionFee",
-        "fields": [
-          {
-            "name": "amount",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int"
-            },
-            "args": [],
-            "isDeprecated": false
-          },
-          {
-            "name": "feeProgramId",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String"
-            },
-            "args": [],
-            "isDeprecated": false
-          },
-          {
-            "name": "feeProgramType",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String"
-            },
-            "args": [],
-            "isDeprecated": false
-          },
-          {
-            "name": "feeType",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String"
-            },
-            "args": [],
-            "isDeprecated": false
-          },
-          {
-            "name": "signature",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String"
-            },
-            "args": [],
-            "isDeprecated": false
-          }
-        ],
-        "interfaces": []
-      },
-      {
-        "kind": "OBJECT",
-        "name": "CheckoutSessionFeesResult",
-        "fields": [
-          {
-            "name": "fees",
-            "type": {
-              "kind": "LIST",
-              "ofType": {
-                "kind": "NON_NULL",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "CheckoutSessionFee"
-                }
-              }
-            },
-            "args": [],
-            "isDeprecated": false
-          }
-        ],
-        "interfaces": []
       },
       {
         "kind": "OBJECT",
@@ -4077,242 +3994,6 @@ const introspection = {
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "CheckoutSessionAddressInput"
-            }
-          }
-        ],
-        "isOneOf": false
-      },
-      {
-        "kind": "OBJECT",
-        "name": "CheckoutSessionTips",
-        "fields": [
-          {
-            "name": "default",
-            "type": {
-              "kind": "OBJECT",
-              "name": "CheckoutSessionTipsDefault"
-            },
-            "args": [],
-            "isDeprecated": false
-          },
-          {
-            "name": "thresholds",
-            "type": {
-              "kind": "LIST",
-              "ofType": {
-                "kind": "NON_NULL",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "CheckoutSessionTipsThreshold"
-                }
-              }
-            },
-            "args": [],
-            "isDeprecated": false
-          }
-        ],
-        "interfaces": []
-      },
-      {
-        "kind": "OBJECT",
-        "name": "CheckoutSessionTipsDefault",
-        "fields": [
-          {
-            "name": "amounts",
-            "type": {
-              "kind": "LIST",
-              "ofType": {
-                "kind": "NON_NULL",
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int"
-                }
-              }
-            },
-            "args": [],
-            "isDeprecated": false
-          },
-          {
-            "name": "percentages",
-            "type": {
-              "kind": "LIST",
-              "ofType": {
-                "kind": "NON_NULL",
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int"
-                }
-              }
-            },
-            "args": [],
-            "isDeprecated": false
-          }
-        ],
-        "interfaces": []
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "CheckoutSessionTipsDefaultInput",
-        "inputFields": [
-          {
-            "name": "amounts",
-            "type": {
-              "kind": "LIST",
-              "ofType": {
-                "kind": "NON_NULL",
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int"
-                }
-              }
-            }
-          },
-          {
-            "name": "percentages",
-            "type": {
-              "kind": "LIST",
-              "ofType": {
-                "kind": "NON_NULL",
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int"
-                }
-              }
-            }
-          }
-        ],
-        "isOneOf": false
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "CheckoutSessionTipsInput",
-        "inputFields": [
-          {
-            "name": "default",
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "CheckoutSessionTipsDefaultInput"
-            }
-          },
-          {
-            "name": "thresholds",
-            "type": {
-              "kind": "LIST",
-              "ofType": {
-                "kind": "NON_NULL",
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "CheckoutSessionTipsThresholdInput"
-                }
-              }
-            }
-          }
-        ],
-        "isOneOf": false
-      },
-      {
-        "kind": "OBJECT",
-        "name": "CheckoutSessionTipsThreshold",
-        "fields": [
-          {
-            "name": "amounts",
-            "type": {
-              "kind": "LIST",
-              "ofType": {
-                "kind": "NON_NULL",
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int"
-                }
-              }
-            },
-            "args": [],
-            "isDeprecated": false
-          },
-          {
-            "name": "maxSubtotal",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int"
-            },
-            "args": [],
-            "isDeprecated": false
-          },
-          {
-            "name": "minSubtotal",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int"
-            },
-            "args": [],
-            "isDeprecated": false
-          },
-          {
-            "name": "percentages",
-            "type": {
-              "kind": "LIST",
-              "ofType": {
-                "kind": "NON_NULL",
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int"
-                }
-              }
-            },
-            "args": [],
-            "isDeprecated": false
-          }
-        ],
-        "interfaces": []
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "CheckoutSessionTipsThresholdInput",
-        "inputFields": [
-          {
-            "name": "amounts",
-            "type": {
-              "kind": "LIST",
-              "ofType": {
-                "kind": "NON_NULL",
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int"
-                }
-              }
-            }
-          },
-          {
-            "name": "maxSubtotal",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int"
-              }
-            }
-          },
-          {
-            "name": "minSubtotal",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int"
-              }
-            }
-          },
-          {
-            "name": "percentages",
-            "type": {
-              "kind": "LIST",
-              "ofType": {
-                "kind": "NON_NULL",
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int"
-                }
-              }
             }
           }
         ],
@@ -6654,46 +6335,6 @@ const introspection = {
         "isOneOf": false
       },
       {
-        "kind": "ENUM",
-        "name": "FeeProgramType",
-        "enumValues": [
-          {
-            "name": "CASH_DISCOUNT",
-            "isDeprecated": false
-          },
-          {
-            "name": "CONVENIENCE_FEE",
-            "isDeprecated": false
-          },
-          {
-            "name": "SERVICE_FEE",
-            "isDeprecated": false
-          },
-          {
-            "name": "SURCHARGE",
-            "isDeprecated": false
-          }
-        ]
-      },
-      {
-        "kind": "ENUM",
-        "name": "FeeType",
-        "enumValues": [
-          {
-            "name": "FIXED",
-            "isDeprecated": false
-          },
-          {
-            "name": "HYBRID",
-            "isDeprecated": false
-          },
-          {
-            "name": "PERCENTAGE",
-            "isDeprecated": false
-          }
-        ]
-      },
-      {
         "kind": "SCALAR",
         "name": "Float"
       },
@@ -6763,24 +6404,6 @@ const introspection = {
           },
           {
             "name": "TO_GO",
-            "isDeprecated": false
-          }
-        ]
-      },
-      {
-        "kind": "ENUM",
-        "name": "FundingSourceType",
-        "enumValues": [
-          {
-            "name": "CREDIT",
-            "isDeprecated": false
-          },
-          {
-            "name": "DEBIT",
-            "isDeprecated": false
-          },
-          {
-            "name": "PREPAID",
             "isDeprecated": false
           }
         ]
@@ -7775,26 +7398,6 @@ const introspection = {
             "isDeprecated": false
           },
           {
-            "name": "calculateCheckoutSessionFees",
-            "type": {
-              "kind": "OBJECT",
-              "name": "CheckoutSessionFeesResult"
-            },
-            "args": [
-              {
-                "name": "fundingSourceType",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "ENUM",
-                    "name": "FundingSourceType"
-                  }
-                }
-              }
-            ],
-            "isDeprecated": false
-          },
-          {
             "name": "calculateCheckoutSessionTaxes",
             "type": {
               "kind": "OBJECT",
@@ -8078,19 +7681,6 @@ const introspection = {
         "name": "MutationAuthorizeCheckoutSessionInput",
         "inputFields": [
           {
-            "name": "fees",
-            "type": {
-              "kind": "LIST",
-              "ofType": {
-                "kind": "NON_NULL",
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "TransactionFeeInput"
-                }
-              }
-            }
-          },
-          {
             "name": "paymentProvider",
             "type": {
               "kind": "NON_NULL",
@@ -8115,13 +7705,6 @@ const introspection = {
                 "kind": "SCALAR",
                 "name": "String"
               }
-            }
-          },
-          {
-            "name": "tipAmount",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int"
             }
           }
         ],
@@ -8150,19 +7733,6 @@ const introspection = {
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "CalculatedTaxesInput"
-            }
-          },
-          {
-            "name": "fees",
-            "type": {
-              "kind": "LIST",
-              "ofType": {
-                "kind": "NON_NULL",
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "TransactionFeeInput"
-                }
-              }
             }
           },
           {
@@ -8248,13 +7818,6 @@ const introspection = {
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "MoneyInput"
-            }
-          },
-          {
-            "name": "tipAmount",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int"
             }
           }
         ],
@@ -8526,13 +8089,6 @@ const introspection = {
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "CheckoutSessionTaxesOptionsInput"
-            }
-          },
-          {
-            "name": "tips",
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "CheckoutSessionTipsInput"
             }
           },
           {
@@ -8965,13 +8521,6 @@ const introspection = {
             "type": {
               "kind": "SCALAR",
               "name": "String"
-            }
-          },
-          {
-            "name": "tips",
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "CheckoutSessionTipsInput"
             }
           },
           {
@@ -11294,57 +10843,6 @@ const introspection = {
           }
         ],
         "interfaces": []
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "TransactionFeeInput",
-        "inputFields": [
-          {
-            "name": "amount",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int"
-              }
-            }
-          },
-          {
-            "name": "feeProgramType",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "ENUM",
-                "name": "FeeProgramType"
-              }
-            }
-          },
-          {
-            "name": "feeType",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "ENUM",
-                "name": "FeeType"
-              }
-            }
-          },
-          {
-            "name": "required",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean"
-            }
-          },
-          {
-            "name": "signature",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String"
-            }
-          }
-        ],
-        "isOneOf": false
       },
       {
         "kind": "OBJECT",

--- a/packages/react/src/lib/godaddy/checkout-queries.ts
+++ b/packages/react/src/lib/godaddy/checkout-queries.ts
@@ -483,6 +483,17 @@ export const DraftOrderQuery = graphql(`
                   name
                   ratePercentage
               }
+              taxes {
+                  amount {
+                      currencyCode
+                      value
+                  }
+                  exempted
+                  id
+                  included
+                  name
+                  ratePercentage
+              }
               totals {
                   discountTotal {
                       currencyCode

--- a/packages/react/src/lib/godaddy/orders-storefront-queries.ts
+++ b/packages/react/src/lib/godaddy/orders-storefront-queries.ts
@@ -136,6 +136,7 @@ export const GetCartOrderQuery = graphql(`
         }
         ratePercentage
         included
+        additional
         exempted
       }
       shipping {

--- a/packages/react/src/lib/godaddy/orders-storefront-queries.ts
+++ b/packages/react/src/lib/godaddy/orders-storefront-queries.ts
@@ -136,7 +136,6 @@ export const GetCartOrderQuery = graphql(`
         }
         ratePercentage
         included
-        additional
         exempted
       }
       shipping {


### PR DESCRIPTION
## Summary

Adds a separate **VAT included** row to checkout totals without changing the amount due. The row sums `amount.value` from order-level taxes where `included === true`, uses the order currency, and appears only when `enableTaxes` is enabled and `includedTaxTotal` is positive. All supported locales include the label, including **GST included** for Australia.

The shared totals component and `CartTotals` accept `includedTaxTotal`. The built-in storefront cart drawer passes `enableTaxes={false}`, so it hides both tax rows.

The checkout draft-order query now selects only `taxes { included amount { value } }`. Both tax rows show loading during tax, shipping, and discount mutations. Tax mutations remain pending until the draft-order refetch settles, keeping totals and tax constituents synchronized; this includes refetch retries and delays rejection of failed tax mutations. Shipping fulfillment synchronization uses the mutation hook's existing refresh instead of issuing another full refetch.

The new `checkout.summary.totals.included-taxes.before` target lets extensions position content before the included-tax row.

### Backend contract

The checkout tax pipeline writes inclusive constituents at the order level with `included: true` and `additional: false`. In `order-api`, `updateOrderTotals` adds order-level taxes to `taxTotal` only when `additional` is true, alongside line-item and shipping tax totals. Therefore these checkout inclusive constituents do not increase `taxTotal` or the amount due; their value is already represented in the supplied price. For example, a $120 price containing $20 VAT remains $120 due, with $20 disclosed as VAT included.

This frontend calculation uses `included`; it does not select or filter `additional`. The backend contract above describes checkout's order-level constituents, not a general exclusion rule for line-item or shipping taxes.

<img width="1120" height="738" alt="Checkout totals showing VAT included" src="https://github.com/user-attachments/assets/87ad6d5c-0f48-4eb4-adeb-c2ee42618cbf" />

## Changeset

- [x] Patch changeset for `@godaddy/react` and `@godaddy/localizations`.

## Test Plan

- Unit coverage sums inclusive constituents, excludes non-inclusive constituents, and handles missing tax data and amounts.
- Checkout coverage verifies the amount within the VAT row, multiple constituents, mixed inclusive/non-inclusive taxes, zero amounts, and `enableTaxes={false}`.
- Loading coverage verifies both tax rows during shipping/discount changes and holds a tax refetch open to verify that stale VAT stays hidden until the refreshed amount arrives or the row disappears.
- Fulfillment coverage verifies new physical line items become `SHIP` with one draft-order refresh through tax recalculation, discount recalculation, and direct-refresh paths.
- Extension coverage includes the new target.
- Validation: `pnpm --filter @godaddy/react typecheck`, `pnpm --filter @godaddy/react lint`, `pnpm --filter @godaddy/react test`, and `pnpm --filter @godaddy/react build`.
