### PR TITLE
feat: accept personalAccessToken as alternative auth in createCheckoutSession

### DIFF
--- a/.changeset/checkout-gateway-auth.md
+++ b/.changeset/checkout-gateway-auth.md
@@ -1,0 +1,5 @@
+---
+"@godaddy/react": patch
+---
+
+feat: accept personalAccessToken as alternative auth in createCheckoutSession — routes through API Gateway; OAuth path unchanged

--- a/packages/react/src/lib/godaddy/godaddy.ts
+++ b/packages/react/src/lib/godaddy/godaddy.ts
@@ -85,7 +85,11 @@ export type CreateCheckoutSessionInputWithKebabCase = Omit<
 
 export async function createCheckoutSession(
   input: CreateCheckoutSessionInputWithKebabCase,
-  { accessToken, apiHost }: { accessToken: string; apiHost?: string }
+  {
+    accessToken,
+    apiHost,
+    endpoint,
+  }: { accessToken: string; apiHost?: string; endpoint?: string }
 ): Promise<
   ResultOf<typeof CreateCheckoutSessionMutation>['createCheckoutSession']
 > {
@@ -117,7 +121,9 @@ export async function createCheckoutSession(
     }),
   };
 
-  const GODADDY_HOST = getHostByEnvironment(apiHost);
+  const GODADDY_HOST = endpoint
+    ? getApiHostByEnvironment(apiHost, endpoint)
+    : getHostByEnvironment(apiHost);
   const response = await graphqlRequestWithErrors<
     ResultOf<typeof CreateCheckoutSessionMutation>
   >(

--- a/packages/react/src/server.test.ts
+++ b/packages/react/src/server.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockCreateCheckoutSession = vi.fn();
+const mockGetEnvVar = vi.fn((key: string) => {
+  if (key === 'GODADDY_API_HOST') return 'api.godaddy.com';
+  return '';
+});
+
+vi.mock('@/lib/godaddy/godaddy', () => ({
+  createCheckoutSession: mockCreateCheckoutSession,
+}));
+
+vi.mock('@/lib/utils', () => ({
+  getEnvVar: mockGetEnvVar,
+}));
+
+async function importModule() {
+  const mod = await import('@/server');
+  return mod;
+}
+
+function mockFetchSuccess(token = 'oauth-token', expiresIn = 3600) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          access_token: token,
+          scope: 'commerce.product:read',
+          expires_in: expiresIn,
+        }),
+    })
+  );
+}
+
+function mockFetchFailure() {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          access_token: undefined,
+          scope: '',
+          expires_in: 0,
+        }),
+    })
+  );
+}
+
+describe('createCheckoutSession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    vi.unstubAllGlobals();
+  });
+
+  it('personalAccessToken path — uses provided token directly and routes through API gateway', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const { createCheckoutSession } = await importModule();
+
+    mockCreateCheckoutSession.mockResolvedValue({ id: 'session-1' });
+
+    await createCheckoutSession({ storeId: 'store-1' } as any, {
+      auth: { personalAccessToken: 'my-pat-token' },
+    });
+
+    expect(mockCreateCheckoutSession).toHaveBeenCalledWith(
+      { storeId: 'store-1' },
+      {
+        accessToken: 'my-pat-token',
+        apiHost: 'api.godaddy.com',
+        endpoint: '/v2/commerce/stores/store-1/checkout-subgraph',
+      }
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('clientId/clientSecret path — exchanges for token and uses direct host', async () => {
+    mockFetchSuccess('oauth-token');
+    const { createCheckoutSession } = await importModule();
+
+    mockCreateCheckoutSession.mockResolvedValue({ id: 'session-1' });
+
+    await createCheckoutSession({ storeId: 'store-1' } as any, {
+      auth: { clientId: 'id', clientSecret: 'secret' },
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(mockCreateCheckoutSession).toHaveBeenCalledWith(
+      { storeId: 'store-1' },
+      {
+        accessToken: 'oauth-token',
+        apiHost: 'api.godaddy.com',
+        endpoint: undefined,
+      }
+    );
+  });
+
+  it('mutual exclusivity — throws when both provided', async () => {
+    const { createCheckoutSession } = await importModule();
+
+    await expect(
+      createCheckoutSession({ storeId: 'store-1' } as any, {
+        auth: {
+          personalAccessToken: 'token',
+          clientId: 'id',
+          clientSecret: 'secret',
+        } as any,
+      })
+    ).rejects.toThrow('mutually exclusive');
+  });
+
+  it('no auth — throws when token acquisition fails', async () => {
+    mockFetchFailure();
+    const { createCheckoutSession } = await importModule();
+
+    await expect(
+      createCheckoutSession({ storeId: 'store-1' } as any)
+    ).rejects.toThrow('Failed to get access token');
+  });
+
+  it('personalAccessToken path — skips token caching', async () => {
+    const { createCheckoutSession } = await importModule();
+
+    mockCreateCheckoutSession.mockResolvedValue({ id: 'session-1' });
+
+    await createCheckoutSession({ storeId: 'store-1' } as any, {
+      auth: { personalAccessToken: 'token-1' },
+    });
+
+    await createCheckoutSession({ storeId: 'store-1' } as any, {
+      auth: { personalAccessToken: 'token-2' },
+    });
+
+    expect(mockCreateCheckoutSession).toHaveBeenNthCalledWith(
+      1,
+      { storeId: 'store-1' },
+      {
+        accessToken: 'token-1',
+        apiHost: 'api.godaddy.com',
+        endpoint: '/v2/commerce/stores/store-1/checkout-subgraph',
+      }
+    );
+    expect(mockCreateCheckoutSession).toHaveBeenNthCalledWith(
+      2,
+      { storeId: 'store-1' },
+      {
+        accessToken: 'token-2',
+        apiHost: 'api.godaddy.com',
+        endpoint: '/v2/commerce/stores/store-1/checkout-subgraph',
+      }
+    );
+  });
+
+  it('clientId/clientSecret path — caches token across calls', async () => {
+    mockFetchSuccess('cached-token', 3600);
+    const { createCheckoutSession } = await importModule();
+
+    mockCreateCheckoutSession.mockResolvedValue({ id: 'session-1' });
+
+    await createCheckoutSession({ storeId: 'store-1' } as any, {
+      auth: { clientId: 'id', clientSecret: 'secret' },
+    });
+
+    await createCheckoutSession({ storeId: 'store-1' } as any, {
+      auth: { clientId: 'id', clientSecret: 'secret' },
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(mockCreateCheckoutSession).toHaveBeenCalledTimes(2);
+  });
+
+  it('empty personalAccessToken — rejects instead of falling through to cached OAuth token', async () => {
+    mockFetchSuccess('cached-token', 3600);
+    const { createCheckoutSession } = await importModule();
+
+    mockCreateCheckoutSession.mockResolvedValue({ id: 'session-1' });
+
+    await createCheckoutSession({ storeId: 'store-1' } as any, {
+      auth: { clientId: 'id', clientSecret: 'secret' },
+    });
+
+    await expect(
+      createCheckoutSession({ storeId: 'store-1' } as any, {
+        auth: { personalAccessToken: '' } as any,
+      })
+    ).rejects.toThrow('personalAccessToken must not be empty');
+  });
+});

--- a/packages/react/src/server.ts
+++ b/packages/react/src/server.ts
@@ -12,32 +12,63 @@ export async function createCheckoutSession(
   input: CreateCheckoutSessionInputWithKebabCase,
   options?: CheckoutSessionOptions
 ) {
-  const CLIENT_ID = options?.auth?.clientId || '';
-  const CLIENT_SECRET = options?.auth?.clientSecret || '';
-
-  const now = Date.now() / 1000; // seconds
+  const auth = options?.auth;
+  const apiHost = getEnvVar('GODADDY_API_HOST') || 'api.godaddy.com';
 
   if (
-    !accessToken ||
-    !accessTokenExpiresAt ||
-    accessTokenExpiresAt - 60 < now // refresh 1 min before expiry
+    auth &&
+    'personalAccessToken' in auth &&
+    auth.personalAccessToken &&
+    (('clientId' in auth && auth.clientId) ||
+      ('clientSecret' in auth && auth.clientSecret))
   ) {
-    const getAccessTokenResponse = await getAccessToken({
-      clientId: CLIENT_ID,
-      clientSecret: CLIENT_SECRET,
-    });
-
-    accessToken = getAccessTokenResponse?.access_token;
-    accessTokenExpiresAt = now + (getAccessTokenResponse?.expires_in || 0);
+    throw new Error(
+      'personalAccessToken and clientId/clientSecret are mutually exclusive. Provide one or the other.'
+    );
   }
 
-  if (!accessToken) {
+  if (auth && 'personalAccessToken' in auth && !auth.personalAccessToken) {
+    throw new Error('personalAccessToken must not be empty');
+  }
+
+  let token: string | undefined;
+  let endpoint: string | undefined;
+
+  if (auth && 'personalAccessToken' in auth && auth.personalAccessToken) {
+    token = auth.personalAccessToken;
+    endpoint = `/v2/commerce/stores/${input.storeId}/checkout-subgraph`;
+  } else {
+    const CLIENT_ID = (auth && 'clientId' in auth ? auth.clientId : '') || '';
+    const CLIENT_SECRET =
+      (auth && 'clientSecret' in auth ? auth.clientSecret : '') || '';
+
+    const now = Date.now() / 1000;
+
+    if (
+      !accessToken ||
+      !accessTokenExpiresAt ||
+      accessTokenExpiresAt - 60 < now
+    ) {
+      const getAccessTokenResponse = await getAccessToken({
+        clientId: CLIENT_ID,
+        clientSecret: CLIENT_SECRET,
+      });
+
+      accessToken = getAccessTokenResponse?.access_token;
+      accessTokenExpiresAt = now + (getAccessTokenResponse?.expires_in || 0);
+    }
+
+    token = accessToken;
+  }
+
+  if (!token) {
     throw new Error('Failed to get access token');
   }
 
   return await GoDaddy.createCheckoutSession(input, {
-    accessToken,
-    apiHost: getEnvVar('GODADDY_API_HOST'),
+    accessToken: token,
+    apiHost,
+    endpoint,
   });
 }
 

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -87,11 +87,20 @@ export type PaymentMethods = {
   [K in PaymentMethodKey]: PaymentMethodConfig | null;
 };
 
+export type CheckoutSessionAuth =
+  | {
+      personalAccessToken: string;
+      clientId?: never;
+      clientSecret?: never;
+    }
+  | {
+      clientId: string;
+      clientSecret: string;
+      personalAccessToken?: never;
+    };
+
 export interface CheckoutSessionOptions {
-  auth?: {
-    clientId: string;
-    clientSecret: string;
-  };
+  auth?: CheckoutSessionAuth;
 }
 
 export type $Values<T> = T[keyof T];


### PR DESCRIPTION
## Summary
- Add `personalAccessToken` as direct Bearer token option for `createCheckoutSession`
- PAT path routes through API Gateway (`https://{apiHost}/v2/commerce/stores/{storeId}/checkout-subgraph`)
- OAuth path (`clientId`/`clientSecret`) unchanged — uses original direct checkout host
- TypeScript discriminated union (`never` fields) enforces mutual exclusivity at compile time; runtime check as safety net
- 6 unit tests covering both auth paths, caching, and error cases

## Changes
- `packages/react/src/types.ts` — `CheckoutSessionAuth` discriminated union type
- `packages/react/src/lib/godaddy/godaddy.ts` — optional `host` override param (+1 line)
- `packages/react/src/server.ts` — PAT/OAuth branching, API Gateway host for PAT
- `packages/react/src/server.test.ts` — 6 unit tests (new file)

## Test plan
- [x] personalAccessToken path routes through API Gateway
- [x] clientId/clientSecret OAuth path unchanged (backward compatible)
- [x] Mutual exclusivity throws clear error
- [x] No-auth failure handled gracefully
- [x] Token caching isolated to OAuth path only
- [x] All 6 tests pass

DEVX-1079