### PR TITLE
Add Razorpay as a standard checkout payment method.

### DIFF
--- a/.changeset/bright-cats-pay.md
+++ b/.changeset/bright-cats-pay.md
@@ -1,0 +1,6 @@
+---
+'@godaddy/react': minor
+'@godaddy/localizations': patch
+---
+
+Add Razorpay as a standard checkout payment method.

--- a/examples/nextjs/app/checkout.tsx
+++ b/examples/nextjs/app/checkout.tsx
@@ -63,8 +63,14 @@ export function CheckoutPage({ session }: { session: CheckoutSession }) {
       ccavenueConfig={
         process.env.NEXT_PUBLIC_CCAVENUE_ACCESS_CODE_ID
           ? {
-              accessCodeId:
-                process.env.NEXT_PUBLIC_CCAVENUE_ACCESS_CODE_ID,
+              accessCodeId: process.env.NEXT_PUBLIC_CCAVENUE_ACCESS_CODE_ID,
+            }
+          : undefined
+      }
+      razorpayConfig={
+        process.env.NEXT_PUBLIC_RAZORPAY_PUBLIC_TOKEN
+          ? {
+              publicToken: process.env.NEXT_PUBLIC_RAZORPAY_PUBLIC_TOKEN,
             }
           : undefined
       }

--- a/examples/nextjs/env.sample
+++ b/examples/nextjs/env.sample
@@ -25,3 +25,6 @@ NEXT_PUBLIC_PAYPAL_CLIENT_ID=
 # MercadoPago Credentials
 NEXT_PUBLIC_MERCADOPAGO_PUBLIC_KEY=
 NEXT_PUBLIC_MERCADOPAGO_COUNTRY=AR
+
+# Razorpay OAuth Public Token (safe for client-side Checkout initialization)
+NEXT_PUBLIC_RAZORPAY_PUBLIC_TOKEN=

--- a/packages/localizations/src/deDe.ts
+++ b/packages/localizations/src/deDe.ts
@@ -112,6 +112,7 @@ export const deDe = {
       offline: 'Offline-Zahlungen',
       mercadopago: 'Mercado Pago',
       ccavenue: 'Mit CCAvenue bezahlen',
+      razorpay: 'Razorpay',
       ach: 'Bankkonto',
     },
     descriptions: {
@@ -125,6 +126,7 @@ export const deDe = {
         'Verwende das MercadoPago-Formular unten, um deinen Kauf sicher abzuschließen.',
       ach: '',
       ccavenue: '',
+      razorpay: '',
     },
     noMethodsAvailable: 'Keine Zahlungsmethoden verfügbar',
     cardNumber: 'Kartennummer',

--- a/packages/localizations/src/enAu.ts
+++ b/packages/localizations/src/enAu.ts
@@ -113,6 +113,7 @@ export const enAu = {
       ach: 'Bank Account',
       mercadopago: 'Mercado Pago',
       ccavenue: 'Pay with CCAvenue',
+      razorpay: 'Razorpay',
     },
     descriptions: {
       creditCard: '',
@@ -125,6 +126,7 @@ export const enAu = {
       mercadopago:
         'Use the MercadoPago form below to complete your purchase securely.',
       ccavenue: '',
+      razorpay: '',
     },
     noMethodsAvailable: 'No payment methods available',
     cardNumber: 'Card number',

--- a/packages/localizations/src/enIe.ts
+++ b/packages/localizations/src/enIe.ts
@@ -113,6 +113,7 @@ export const enIe = {
       ach: 'Bank Account',
       mercadopago: 'Mercado Pago',
       ccavenue: 'Pay with CCAvenue',
+      razorpay: 'Razorpay',
     },
     descriptions: {
       creditCard: '',
@@ -125,6 +126,7 @@ export const enIe = {
       mercadopago:
         'Use the MercadoPago form below to complete your purchase securely.',
       ccavenue: '',
+      razorpay: '',
     },
     noMethodsAvailable: 'No payment methods available',
     cardNumber: 'Card number',

--- a/packages/localizations/src/enUs.ts
+++ b/packages/localizations/src/enUs.ts
@@ -113,6 +113,7 @@ export const enUs = {
       ach: 'Bank Account',
       mercadopago: 'Mercado Pago',
       ccavenue: 'Pay with CCAvenue',
+      razorpay: 'Razorpay',
     },
     descriptions: {
       creditCard: '',
@@ -125,6 +126,7 @@ export const enUs = {
       mercadopago:
         'Use the MercadoPago form below to complete your purchase securely.',
       ccavenue: '',
+      razorpay: '',
     },
     noMethodsAvailable: 'No payment methods available',
     cardNumber: 'Card number',

--- a/packages/localizations/src/esAr.ts
+++ b/packages/localizations/src/esAr.ts
@@ -114,6 +114,7 @@ export const esAr = {
       ach: 'Cuenta Bancaria',
       mercadopago: 'Mercado Pago',
       ccavenue: 'الدفع عبر CCAvenue',
+      razorpay: 'Razorpay',
     },
     descriptions: {
       creditCard: '',
@@ -126,6 +127,7 @@ export const esAr = {
       mercadopago:
         'Usa el formulario de MercadoPago a continuación para completar tu compra de forma segura.',
       ccavenue: '',
+      razorpay: '',
     },
     noMethodsAvailable: 'No hay métodos de pago disponibles',
     cardNumber: 'Número de tarjeta',

--- a/packages/localizations/src/esCl.ts
+++ b/packages/localizations/src/esCl.ts
@@ -114,6 +114,7 @@ export const esCl = {
       ach: 'Cuenta Bancaria',
       mercadopago: 'Mercado Pago',
       ccavenue: 'Pagar con CCAvenue',
+      razorpay: 'Razorpay',
     },
     descriptions: {
       creditCard: '',
@@ -126,6 +127,7 @@ export const esCl = {
       mercadopago:
         'Usa el formulario de MercadoPago a continuación para completar tu compra de forma segura.',
       ccavenue: '',
+      razorpay: '',
     },
     noMethodsAvailable: 'No hay métodos de pago disponibles',
     cardNumber: 'Número de tarjeta',

--- a/packages/localizations/src/esCo.ts
+++ b/packages/localizations/src/esCo.ts
@@ -114,6 +114,7 @@ export const esCo = {
       ach: 'Cuenta bancaria',
       mercadopago: 'Mercado Pago',
       ccavenue: 'Pagar con CCAvenue',
+      razorpay: 'Razorpay',
     },
     descriptions: {
       creditCard: '',
@@ -126,6 +127,7 @@ export const esCo = {
       mercadopago:
         'Usa el formulario de MercadoPago a continuación para completar tu compra de forma segura.',
       ccavenue: '',
+      razorpay: '',
     },
     noMethodsAvailable: 'No hay métodos de pago disponibles',
     cardNumber: 'Número de tarjeta',

--- a/packages/localizations/src/esEs.ts
+++ b/packages/localizations/src/esEs.ts
@@ -114,6 +114,7 @@ export const esEs = {
       ach: 'Cuenta bancaria',
       mercadopago: 'Mercado Pago',
       ccavenue: 'Pagar con CCAvenue',
+      razorpay: 'Razorpay',
     },
     descriptions: {
       creditCard: '',
@@ -126,6 +127,7 @@ export const esEs = {
       mercadopago:
         'Usa el formulario de MercadoPago a continuación para completar tu compra de forma segura.',
       ccavenue: '',
+      razorpay: '',
     },
     noMethodsAvailable: 'No hay métodos de pago disponibles',
     cardNumber: 'Número de tarjeta',

--- a/packages/localizations/src/esMx.ts
+++ b/packages/localizations/src/esMx.ts
@@ -114,6 +114,7 @@ export const esMx = {
       ach: 'Cuenta Bancaria',
       mercadopago: 'Mercado Pago',
       ccavenue: 'Pagar con CCAvenue',
+      razorpay: 'Razorpay',
     },
     descriptions: {
       creditCard: '',
@@ -126,6 +127,7 @@ export const esMx = {
       mercadopago:
         'Usa el formulario de MercadoPago a continuación para completar tu compra de forma segura.',
       ccavenue: '',
+      razorpay: '',
     },
     noMethodsAvailable: 'No hay métodos de pago disponibles',
     cardNumber: 'Número de tarjeta',

--- a/packages/localizations/src/esPe.ts
+++ b/packages/localizations/src/esPe.ts
@@ -114,6 +114,7 @@ export const esPe = {
       ach: 'Cuenta Bancaria',
       mercadopago: 'Mercado Pago',
       ccavenue: 'Pagar con CCAvenue',
+      razorpay: 'Razorpay',
     },
     descriptions: {
       creditCard: '',
@@ -126,6 +127,7 @@ export const esPe = {
       mercadopago:
         'Usa el formulario de MercadoPago a continuación para completar tu compra de forma segura.',
       ccavenue: '',
+      razorpay: '',
     },
     noMethodsAvailable: 'No hay métodos de pago disponibles',
     cardNumber: 'Número de tarjeta',

--- a/packages/localizations/src/esUs.ts
+++ b/packages/localizations/src/esUs.ts
@@ -114,6 +114,7 @@ export const esUs = {
       ach: 'Cuenta Bancaria',
       mercadopago: 'Mercado Pago',
       ccavenue: 'Pagar con CCAvenue',
+      razorpay: 'Razorpay',
     },
     descriptions: {
       creditCard: '',
@@ -126,6 +127,7 @@ export const esUs = {
       mercadopago:
         'Usa el formulario de MercadoPago a continuación para completar tu compra de forma segura.',
       ccavenue: '',
+      razorpay: '',
     },
     noMethodsAvailable: 'No hay métodos de pago disponibles',
     cardNumber: 'Número de tarjeta',

--- a/packages/localizations/src/frCa.ts
+++ b/packages/localizations/src/frCa.ts
@@ -114,6 +114,7 @@ export const frCa = {
       ach: 'Compte bancaire',
       mercadopago: 'Mercado Pago',
       ccavenue: 'Payer avec CCAvenue',
+      razorpay: 'Razorpay',
     },
     descriptions: {
       creditCard: '',
@@ -126,6 +127,7 @@ export const frCa = {
       mercadopago:
         'Utilisez le formulaire MercadoPago ci-dessous pour finaliser votre achat en toute sécurité.',
       ccavenue: '',
+      razorpay: '',
     },
     noMethodsAvailable: 'Aucune méthode de paiement disponible',
     cardNumber: 'Numéro de carte',

--- a/packages/localizations/src/frFr.ts
+++ b/packages/localizations/src/frFr.ts
@@ -114,6 +114,7 @@ export const frFr = {
       ach: 'Compte bancaire',
       mercadopago: 'Mercado Pago',
       ccavenue: 'Payer avec CCAvenue',
+      razorpay: 'Razorpay',
     },
     descriptions: {
       creditCard: '',
@@ -126,6 +127,7 @@ export const frFr = {
       mercadopago:
         'Utilisez le formulaire MercadoPago ci-dessous pour finaliser votre achat en toute sécurité.',
       ccavenue: '',
+      razorpay: '',
     },
     noMethodsAvailable: 'Aucune méthode de paiement disponible',
     cardNumber: 'Numéro de carte',

--- a/packages/localizations/src/idId.ts
+++ b/packages/localizations/src/idId.ts
@@ -113,6 +113,7 @@ export const idId = {
       ach: 'Rekening Bank',
       mercadopago: 'Mercado Pago',
       ccavenue: 'Bayar dengan CCAvenue',
+      razorpay: 'Razorpay',
     },
     descriptions: {
       creditCard: '',
@@ -125,6 +126,7 @@ export const idId = {
       mercadopago:
         'Gunakan formulir MercadoPago di bawah untuk menyelesaikan pembelian Anda dengan aman.',
       ccavenue: '',
+      razorpay: '',
     },
     noMethodsAvailable: 'Tidak ada metode pembayaran tersedia',
     cardNumber: 'Nomor kartu',

--- a/packages/localizations/src/itIt.ts
+++ b/packages/localizations/src/itIt.ts
@@ -114,6 +114,7 @@ export const itIt = {
       ach: 'Conto Bancario',
       mercadopago: 'Mercado Pago',
       ccavenue: 'Paga con CCAvenue',
+      razorpay: 'Razorpay',
     },
     descriptions: {
       creditCard: '',
@@ -126,6 +127,7 @@ export const itIt = {
       mercadopago:
         'Usa il modulo MercadoPago qui sotto per completare l’acquisto in modo sicuro.',
       ccavenue: '',
+      razorpay: '',
     },
     noMethodsAvailable: 'Nessun metodo di pagamento disponibile',
     cardNumber: 'Numero della carta',

--- a/packages/localizations/src/ptBr.ts
+++ b/packages/localizations/src/ptBr.ts
@@ -113,6 +113,7 @@ export const ptBr = {
       ach: 'Conta Bancária',
       mercadopago: 'Mercado Pago',
       ccavenue: 'Pagar com CCAvenue',
+      razorpay: 'Razorpay',
     },
     descriptions: {
       creditCard: '',
@@ -125,6 +126,7 @@ export const ptBr = {
       mercadopago:
         'Use o formulário do MercadoPago abaixo para concluir sua compra com segurança.',
       ccavenue: '',
+      razorpay: '',
     },
     noMethodsAvailable: 'Nenhum método de pagamento disponível',
     cardNumber: 'Número do cartão',

--- a/packages/localizations/src/qaPs.ts
+++ b/packages/localizations/src/qaPs.ts
@@ -114,6 +114,7 @@ export const qaPs = {
       ach: '[Bâñk Âççöüñţ Þâÿmëñţ]',
       mercadopago: 'Mercado Pago',
       ccavenue: '[Þâÿ ïñ ÇÇÂvëñûë]',
+      razorpay: '[Râžörþâÿ]',
     },
     descriptions: {
       creditCard: '',
@@ -126,6 +127,7 @@ export const qaPs = {
       mercadopago:
         '[Üšë ţhë MërçâðöÞâgö förm këlöw ţö çömþlëţë ÿöür þürçhâšë šëçürëlÿ.]',
       ccavenue: '',
+      razorpay: '',
     },
     noMethodsAvailable: '[Ñö þâÿmëñţ mëţhödš âvâîlâblë âţ ţhîš ţîmë]',
     cardNumber: '[Çârd ñümkër îñþüţ fîëld]',

--- a/packages/localizations/src/trTr.ts
+++ b/packages/localizations/src/trTr.ts
@@ -113,6 +113,7 @@ export const trTr = {
       ach: 'Banka Hesabı',
       mercadopago: 'Mercado Pago',
       ccavenue: 'CCAvenue ile öde',
+      razorpay: 'Razorpay',
     },
     descriptions: {
       creditCard: '',
@@ -125,6 +126,7 @@ export const trTr = {
       mercadopago:
         'Satın alımınızı güvenle tamamlamak için aşağıdaki MercadoPago formunu kullanın.',
       ccavenue: '',
+      razorpay: '',
     },
     noMethodsAvailable: 'Kullanılabilir ödeme yöntemi yok',
     cardNumber: 'Kart numarası',

--- a/packages/localizations/src/viVn.ts
+++ b/packages/localizations/src/viVn.ts
@@ -113,6 +113,7 @@ export const viVn = {
       ach: 'Tài khoản ngân hàng',
       mercadopago: 'Mercado Pago',
       ccavenue: 'Thanh toán bằng CCAvenue',
+      razorpay: 'Razorpay',
     },
     descriptions: {
       creditCard: '',
@@ -125,6 +126,7 @@ export const viVn = {
       mercadopago:
         'Hãy sử dụng biểu mẫu MercadoPago bên dưới để hoàn tất mua hàng một cách an toàn.',
       ccavenue: '',
+      razorpay: '',
     },
     noMethodsAvailable: 'Không có phương thức thanh toán nào',
     cardNumber: 'Số thẻ',

--- a/packages/localizations/src/zhCn.ts
+++ b/packages/localizations/src/zhCn.ts
@@ -109,6 +109,7 @@ export const zhCn = {
       ach: '银行账户',
       mercadopago: 'Mercado Pago',
       ccavenue: '使用 CCAvenue 支付',
+      razorpay: 'Razorpay',
     },
     descriptions: {
       creditCard: '',
@@ -120,6 +121,7 @@ export const zhCn = {
       ach: '',
       mercadopago: '请使用下方的 MercadoPago 表单安全完成购买。',
       ccavenue: '',
+      razorpay: '',
     },
     noMethodsAvailable: '暂无可用的付款方式',
     cardNumber: '卡号',

--- a/packages/localizations/src/zhSg.ts
+++ b/packages/localizations/src/zhSg.ts
@@ -109,6 +109,7 @@ export const zhSg = {
       ach: '银行账户',
       mercadopago: 'Mercado Pago',
       ccavenue: '使用 CCAvenue 支付',
+      razorpay: 'Razorpay',
     },
     descriptions: {
       creditCard: '',
@@ -120,6 +121,7 @@ export const zhSg = {
       ach: '',
       mercadopago: '请使用下方的 MercadoPago 表单安全完成购买。',
       ccavenue: '',
+      razorpay: '',
     },
     noMethodsAvailable: '无可用付款方式',
     cardNumber: '卡号',

--- a/packages/react/src/components/checkout/__tests__/checkout-razorpay.test.tsx
+++ b/packages/react/src/components/checkout/__tests__/checkout-razorpay.test.tsx
@@ -1,0 +1,41 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import {
+  buildCheckoutSession,
+  renderCheckout,
+  waitForCheckoutReady,
+} from './checkout-test-env';
+
+function buildRazorpaySession() {
+  const session = buildCheckoutSession();
+  session.paymentMethods = {
+    razorpay: {
+      type: 'razorpay',
+      processor: 'razorpay',
+      checkoutTypes: ['standard'],
+    },
+  } as never;
+  return session;
+}
+
+describe('Razorpay payment method', () => {
+  it('renders the Razorpay checkout button when session and public token are configured', async () => {
+    renderCheckout({
+      session: buildRazorpaySession(),
+      checkoutProps: {
+        razorpayConfig: { publicToken: 'rzp_test_public' },
+      },
+    });
+    await waitForCheckoutReady();
+
+    expect(await screen.findByTestId('mock-razorpay-button')).toBeVisible();
+  });
+
+  it('hides Razorpay when the public token is unavailable', async () => {
+    renderCheckout({ session: buildRazorpaySession() });
+    await waitForCheckoutReady();
+
+    expect(screen.getByText('No payment methods available')).toBeVisible();
+    expect(screen.queryByTestId('mock-razorpay-button')).not.toBeInTheDocument();
+  });
+});

--- a/packages/react/src/components/checkout/__tests__/checkout-test-env.tsx
+++ b/packages/react/src/components/checkout/__tests__/checkout-test-env.tsx
@@ -91,6 +91,15 @@ vi.mock(
   })
 );
 
+vi.mock(
+  '@/components/checkout/payment/checkout-buttons/razorpay/razorpay',
+  inertButtonMock({
+    exportName: 'RazorpayCheckoutButton',
+    testId: 'mock-razorpay-button',
+    label: 'Pay with Razorpay',
+  })
+);
+
 // The dedicated express buttons (paymentMethods.express.processor=godaddy /
 // stripe). Their real implementations open a wallet sheet, run their own
 // shipping/tax/coupon flow, and then call confirmCheckout with isExpress=true

--- a/packages/react/src/components/checkout/checkout.tsx
+++ b/packages/react/src/components/checkout/checkout.tsx
@@ -94,6 +94,10 @@ export type CCAvenueConfig = {
   accessCodeId: string;
 };
 
+export type RazorpayConfig = {
+  publicToken: string;
+};
+
 interface CheckoutContextValue {
   elements?: CheckoutElements;
   targets?: Partial<
@@ -108,6 +112,7 @@ interface CheckoutContextValue {
   paypalConfig?: PayPalConfig;
   mercadoPagoConfig?: MercadoPagoConfig;
   ccavenueConfig?: CCAvenueConfig;
+  razorpayConfig?: RazorpayConfig;
   isConfirmingCheckout: boolean;
   setIsConfirmingCheckout: (isConfirming: boolean) => void;
   checkoutErrors?: string[] | undefined;
@@ -214,6 +219,7 @@ export interface CheckoutProps {
   paypalConfig?: PayPalConfig;
   mercadoPagoConfig?: MercadoPagoConfig;
   ccavenueConfig?: CCAvenueConfig;
+  razorpayConfig?: RazorpayConfig;
   layout?: LayoutSection[];
   direction?: 'ltr' | 'rtl';
   showStoreHours?: boolean;
@@ -239,6 +245,7 @@ export function Checkout(props: CheckoutProps) {
     paypalConfig,
     mercadoPagoConfig,
     ccavenueConfig,
+    razorpayConfig,
     isCheckoutDisabled,
   } = props;
 
@@ -333,6 +340,7 @@ export function Checkout(props: CheckoutProps) {
           mercadoPagoConfig,
           paypalConfig,
           ccavenueConfig,
+          razorpayConfig,
           requiredFields,
           isConfirmingCheckout,
           setIsConfirmingCheckout,

--- a/packages/react/src/components/checkout/payment/checkout-buttons/razorpay/razorpay.test.tsx
+++ b/packages/react/src/components/checkout/payment/checkout-buttons/razorpay/razorpay.test.tsx
@@ -1,0 +1,227 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  RAZORPAY_CALLBACK_TIMEOUT_MS,
+  RazorpayCheckoutButton,
+} from './razorpay';
+
+const mocks = vi.hoisted(() => ({
+  authorize: vi.fn(),
+  confirm: vi.fn(),
+  flush: vi.fn(),
+  setCheckoutErrors: vi.fn(),
+  trigger: vi.fn(),
+  setFocus: vi.fn(),
+  getValues: vi.fn(),
+}));
+
+vi.mock('@/components/checkout/checkout', () => ({
+  useCheckoutContext: () => ({
+    razorpayConfig: { publicToken: 'rzp_test_public' },
+    session: { storeName: 'Test Store' },
+    setCheckoutErrors: mocks.setCheckoutErrors,
+    isConfirmingCheckout: false,
+  }),
+}));
+
+vi.mock(
+  '@/components/checkout/payment/utils/use-authorize-checkout',
+  () => ({
+    useAuthorizeCheckout: () => ({
+      mutateAsync: mocks.authorize,
+      isPending: false,
+    }),
+  })
+);
+
+vi.mock('@/components/checkout/payment/utils/use-confirm-checkout', () => ({
+  PaymentProvider: { RAZORPAY: 'RAZORPAY' },
+  useConfirmCheckout: () => ({ mutateAsync: mocks.confirm }),
+}));
+
+vi.mock(
+  '@/components/checkout/payment/utils/use-flush-checkout-sync',
+  () => ({
+    useFlushCheckoutSync: () => mocks.flush,
+  })
+);
+
+vi.mock(
+  '@/components/checkout/payment/utils/use-is-payment-disabled',
+  () => ({
+    useIsPaymentDisabled: () => false,
+  })
+);
+
+vi.mock('@/components/checkout/payment/utils/use-load-razorpay', () => ({
+  useLoadRazorpay: () => ({
+    isRazorpayLoaded: true,
+    isRazorpayLoadFailed: false,
+  }),
+}));
+
+vi.mock('react-hook-form', () => ({
+  useFormContext: () => ({
+    trigger: mocks.trigger,
+    setFocus: mocks.setFocus,
+    getValues: mocks.getValues,
+    formState: { errors: {} },
+  }),
+}));
+
+type CapturedOptions = {
+  key: string;
+  amount: number;
+  currency: string;
+  name?: string;
+  description: string;
+  order_id: string;
+  prefill?: { name?: string; email?: string; contact?: string };
+  handler: (response: {
+    razorpay_payment_id?: string;
+    razorpay_order_id?: string;
+    razorpay_signature?: string;
+  }) => void;
+};
+
+describe('RazorpayCheckoutButton', () => {
+  let capturedOptions: CapturedOptions | undefined;
+  let paymentFailedHandler: (() => void) | undefined;
+  const open = vi.fn();
+  const close = vi.fn();
+  const on = vi.fn((event: string, handler: () => void) => {
+    if (event === 'payment.failed') paymentFailedHandler = handler;
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedOptions = undefined;
+    paymentFailedHandler = undefined;
+    mocks.trigger.mockResolvedValue(true);
+    mocks.flush.mockResolvedValue({
+      latestOrder: {
+        id: 'draft-order-1',
+        totals: { total: { value: 2500, currencyCode: 'INR' } },
+        billing: {
+          firstName: 'Test',
+          lastName: 'Buyer',
+          email: 'buyer@example.com',
+          phone: '(201) 555-0123',
+          address: { countryCode: 'US' },
+        },
+      },
+    });
+    mocks.authorize.mockResolvedValue({
+      transactionRefNum: 'order_razorpay_123',
+    });
+    mocks.confirm.mockResolvedValue(undefined);
+
+    Object.defineProperty(window, 'Razorpay', {
+      configurable: true,
+      value: class {
+        constructor(options: CapturedOptions) {
+          capturedOptions = options;
+        }
+
+        open = open;
+        close = close;
+        on = on;
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('authorizes an order, opens Checkout, and confirms the signed handler payload', async () => {
+    render(<RazorpayCheckoutButton />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Pay now' }));
+
+    await waitFor(() => {
+      expect(open).toHaveBeenCalledOnce();
+    });
+
+    expect(mocks.flush).toHaveBeenCalledWith({
+      includeCurrentFormDiff: true,
+    });
+    expect(mocks.authorize).toHaveBeenCalledWith({
+      paymentType: 'razorpay',
+      paymentProvider: 'RAZORPAY',
+    });
+    expect(capturedOptions).toMatchObject({
+      key: 'rzp_test_public',
+      amount: 2500,
+      currency: 'INR',
+      name: 'Test Store',
+      description: 'draft-order-1',
+      order_id: 'order_razorpay_123',
+      prefill: {
+        name: 'Test Buyer',
+        email: 'buyer@example.com',
+        contact: '+12015550123',
+      },
+    });
+    expect(on).toHaveBeenCalledWith('payment.failed', expect.any(Function));
+
+    capturedOptions?.handler({
+      razorpay_payment_id: 'pay_razorpay_456',
+      razorpay_order_id: 'order_razorpay_123',
+      razorpay_signature: 'signature_789',
+    });
+
+    await waitFor(() => {
+      expect(mocks.confirm).toHaveBeenCalledOnce();
+    });
+
+    const confirmInput = mocks.confirm.mock.calls[0][0];
+    expect(confirmInput).toMatchObject({
+      paymentType: 'razorpay',
+      paymentProvider: 'RAZORPAY',
+    });
+    const base64 = confirmInput.paymentToken
+      .replace(/-/g, '+')
+      .replace(/_/g, '/');
+    const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, '=');
+    expect(JSON.parse(atob(padded))).toEqual({
+      v: 1,
+      paymentId: 'pay_razorpay_456',
+      orderId: 'order_razorpay_123',
+      signature: 'signature_789',
+    });
+  });
+
+  it('does not confirm when Razorpay reports a failed payment', async () => {
+    render(<RazorpayCheckoutButton />);
+    fireEvent.click(screen.getByRole('button', { name: 'Pay now' }));
+
+    await waitFor(() => expect(open).toHaveBeenCalledOnce());
+    act(() => {
+      paymentFailedHandler?.();
+    });
+
+    expect(mocks.confirm).not.toHaveBeenCalled();
+    expect(screen.getByText('Error processing payment')).toBeTruthy();
+  });
+
+  it('closes Checkout when no callback arrives within two minutes', async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+    render(<RazorpayCheckoutButton />);
+    fireEvent.click(screen.getByRole('button', { name: 'Pay now' }));
+
+    await waitFor(() => expect(open).toHaveBeenCalledOnce());
+    const timeoutCall = setTimeoutSpy.mock.calls.find(
+      ([, delay]) => delay === RAZORPAY_CALLBACK_TIMEOUT_MS
+    );
+    expect(timeoutCall).toBeDefined();
+
+    act(() => {
+      (timeoutCall?.[0] as () => void)();
+    });
+
+    expect(close).toHaveBeenCalledOnce();
+    expect(mocks.confirm).not.toHaveBeenCalled();
+    expect(screen.getByText('Error processing payment')).toBeTruthy();
+  });
+});

--- a/packages/react/src/components/checkout/payment/checkout-buttons/razorpay/razorpay.tsx
+++ b/packages/react/src/components/checkout/payment/checkout-buttons/razorpay/razorpay.tsx
@@ -1,0 +1,261 @@
+import { LoaderCircle } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { useCheckoutContext } from '@/components/checkout/checkout';
+import { useAuthorizeCheckout } from '@/components/checkout/payment/utils/use-authorize-checkout';
+import { encodeRazorpayPaymentToken } from '@/components/checkout/payment/utils/razorpay-payment-token';
+import {
+  PaymentProvider,
+  useConfirmCheckout,
+} from '@/components/checkout/payment/utils/use-confirm-checkout';
+import { useFlushCheckoutSync } from '@/components/checkout/payment/utils/use-flush-checkout-sync';
+import { useIsPaymentDisabled } from '@/components/checkout/payment/utils/use-is-payment-disabled';
+import { useLoadRazorpay } from '@/components/checkout/payment/utils/use-load-razorpay';
+import { normalizePhoneForRazorpay } from '@/components/checkout/utils/checkout-transformers';
+import { Button } from '@/components/ui/button';
+import { useGoDaddyContext } from '@/godaddy-provider';
+import { GraphQLErrorWithCodes } from '@/lib/graphql-with-errors';
+import { PaymentMethodType } from '@/types';
+
+export const RAZORPAY_CALLBACK_TIMEOUT_MS = 2 * 60 * 1000;
+
+type RazorpaySuccessResponse = {
+  razorpay_payment_id?: string;
+  razorpay_order_id?: string;
+  razorpay_signature?: string;
+};
+
+type RazorpayOptions = {
+  key: string;
+  amount: number;
+  currency: string;
+  name?: string;
+  description: string;
+  order_id: string;
+  prefill?: {
+    name?: string;
+    email?: string;
+    contact?: string;
+  };
+  handler: (response: RazorpaySuccessResponse) => void;
+  modal: {
+    ondismiss: () => void;
+  };
+};
+
+type RazorpayInstance = {
+  open: () => void;
+  close: () => void;
+  on: (
+    event: 'payment.failed',
+    handler: (response: unknown) => void
+  ) => void;
+};
+
+type RazorpayConstructor = new (options: RazorpayOptions) => RazorpayInstance;
+
+function getRazorpayConstructor(): RazorpayConstructor | undefined {
+  return (window as Window & { Razorpay?: RazorpayConstructor }).Razorpay;
+}
+
+export function RazorpayCheckoutButton() {
+  const { t } = useGoDaddyContext();
+  const {
+    razorpayConfig,
+    session,
+    setCheckoutErrors,
+    isConfirmingCheckout,
+  } = useCheckoutContext();
+  const form = useFormContext();
+  const authorizeCheckout = useAuthorizeCheckout();
+  const confirmCheckout = useConfirmCheckout();
+  const flushCheckoutSync = useFlushCheckoutSync();
+  const isPaymentDisabled = useIsPaymentDisabled();
+  const { isRazorpayLoaded, isRazorpayLoadFailed } = useLoadRazorpay();
+  const [isWidgetOpen, setIsWidgetOpen] = useState(false);
+  const [error, setError] = useState('');
+  const callbackTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearCallbackTimeout = useCallback(() => {
+    if (callbackTimeoutRef.current) {
+      clearTimeout(callbackTimeoutRef.current);
+      callbackTimeoutRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => clearCallbackTimeout, [clearCallbackTimeout]);
+
+  const handlePaymentSuccess = useCallback(
+    async (response: RazorpaySuccessResponse) => {
+      clearCallbackTimeout();
+      const paymentId = response.razorpay_payment_id;
+      const orderId = response.razorpay_order_id;
+      const signature = response.razorpay_signature;
+      if (!paymentId || !orderId || !signature) {
+        setError(t.errors.errorProcessingPayment);
+        setIsWidgetOpen(false);
+        return;
+      }
+
+      try {
+        const paymentToken = encodeRazorpayPaymentToken({
+          v: 1,
+          paymentId,
+          orderId,
+          signature,
+        });
+        await confirmCheckout.mutateAsync({
+          paymentToken,
+          paymentType: PaymentMethodType.RAZORPAY,
+          paymentProvider: PaymentProvider.RAZORPAY,
+        });
+        setError('');
+      } catch (err: unknown) {
+        if (err instanceof GraphQLErrorWithCodes) {
+          setCheckoutErrors(err.codes);
+        } else {
+          setError(t.errors.errorProcessingPayment);
+        }
+      } finally {
+        setIsWidgetOpen(false);
+      }
+    },
+    [
+      confirmCheckout,
+      clearCallbackTimeout,
+      setCheckoutErrors,
+      t.errors.errorProcessingPayment,
+    ]
+  );
+
+  const handlePaymentFailure = useCallback(() => {
+    setError(t.errors.errorProcessingPayment);
+  }, [t.errors.errorProcessingPayment]);
+
+  const handleClick = async () => {
+    if (isWidgetOpen || authorizeCheckout.isPending || isConfirmingCheckout) {
+      return;
+    }
+
+    const valid = await form.trigger();
+    if (!valid) {
+      const firstError = Object.keys(form.formState.errors)[0];
+      if (firstError) form.setFocus(firstError);
+      return;
+    }
+
+    setCheckoutErrors(undefined);
+    setError('');
+
+    try {
+      const { latestOrder } = await flushCheckoutSync({
+        includeCurrentFormDiff: true,
+      });
+      const total = latestOrder?.totals?.total;
+      if (
+        !latestOrder?.id ||
+        total?.value == null ||
+        !total.currencyCode
+      ) {
+        throw new Error('Synchronized draft order is unavailable');
+      }
+
+      const contact = latestOrder.billing ?? latestOrder.shipping;
+      const buyerName = [contact?.firstName, contact?.lastName]
+        .filter(Boolean)
+        .join(' ');
+      const buyerPhone = normalizePhoneForRazorpay(
+        contact?.phone,
+        contact?.address?.countryCode
+      );
+
+      const authorization = await authorizeCheckout.mutateAsync({
+        paymentType: PaymentMethodType.RAZORPAY,
+        paymentProvider: PaymentProvider.RAZORPAY,
+      });
+      const orderId = authorization?.transactionRefNum;
+      const Razorpay = getRazorpayConstructor();
+      if (
+        !orderId?.startsWith('order_') ||
+        !razorpayConfig?.publicToken ||
+        !isRazorpayLoaded ||
+        !Razorpay
+      ) {
+        throw new Error('Razorpay Checkout configuration is unavailable');
+      }
+
+      const widget = new Razorpay({
+        key: razorpayConfig.publicToken,
+        amount: total.value,
+        currency: total.currencyCode,
+        name: session?.storeName || undefined,
+        description: latestOrder.id,
+        order_id: orderId,
+        prefill: {
+          name: buyerName || undefined,
+          email: contact?.email || undefined,
+          contact: buyerPhone,
+        },
+        handler: response => {
+          void handlePaymentSuccess(response);
+        },
+        modal: {
+          ondismiss: () => {
+            clearCallbackTimeout();
+            setIsWidgetOpen(false);
+          },
+        },
+      });
+      widget.on('payment.failed', handlePaymentFailure);
+
+      setIsWidgetOpen(true);
+      callbackTimeoutRef.current = setTimeout(() => {
+        callbackTimeoutRef.current = null;
+        widget.close();
+        setIsWidgetOpen(false);
+        setError(t.errors.errorProcessingPayment);
+      }, RAZORPAY_CALLBACK_TIMEOUT_MS);
+      widget.open();
+    } catch (err: unknown) {
+      clearCallbackTimeout();
+      setIsWidgetOpen(false);
+      if (err instanceof GraphQLErrorWithCodes) {
+        setCheckoutErrors(err.codes);
+      } else {
+        setError(t.errors.errorProcessingPayment);
+      }
+    }
+  };
+
+  const isBusy =
+    isPaymentDisabled ||
+    isWidgetOpen ||
+    authorizeCheckout.isPending ||
+    isConfirmingCheckout;
+
+  return (
+    <div className='flex flex-col gap-2'>
+      {error || isRazorpayLoadFailed ? (
+        <p className='text-[0.8rem] font-medium text-destructive'>
+          {error || t.errors.failedToInitializePayment}
+        </p>
+      ) : null}
+      <Button
+        type='button'
+        size='lg'
+        className='w-full'
+        disabled={isBusy || !isRazorpayLoaded || !razorpayConfig?.publicToken}
+        onClick={handleClick}
+      >
+        {isBusy ? (
+          <>
+            <LoaderCircle className='h-5 w-5 animate-spin' />
+            {t.payment.processingPayment}
+          </>
+        ) : (
+          t.payment.payNow
+        )}
+      </Button>
+    </div>
+  );
+}

--- a/packages/react/src/components/checkout/payment/icons/Razorpay.tsx
+++ b/packages/react/src/components/checkout/payment/icons/Razorpay.tsx
@@ -1,0 +1,19 @@
+export const RazorpayIcon = ({ className }: { className?: string }) => {
+  return (
+    <svg
+      className={className}
+      xmlns='http://www.w3.org/2000/svg'
+      viewBox='0 0 640 640'
+      fill='none'
+    >
+      <title>Razorpay</title>
+      <path
+        fill='#3395FF'
+        d='m299.6 262.7-15.7 58 90-58.3-59 220h60l87-325'
+      />
+      <path fill='#072654' d='m202.6 390-24.8 92.4h122.7l50.2-188-148 95.5' />
+    </svg>
+  );
+};
+
+export default RazorpayIcon;

--- a/packages/react/src/components/checkout/payment/lazy-payment-loader.tsx
+++ b/packages/react/src/components/checkout/payment/lazy-payment-loader.tsx
@@ -152,6 +152,11 @@ const LazyComponents = {
       '@/components/checkout/payment/checkout-buttons/ccavenue/ccavenue'
     ).then(module => ({ default: module.CCAvenueCheckoutButton }))
   ),
+  RazorpayCheckoutButton: lazy(() =>
+    import(
+      '@/components/checkout/payment/checkout-buttons/razorpay/razorpay'
+    ).then(module => ({ default: module.RazorpayCheckoutButton }))
+  ),
 
   // Container Components
   CreditCardContainer: lazy(() =>
@@ -238,6 +243,11 @@ type PaymentComponentRegistry = {
       button: PaymentComponentKey;
     };
   };
+  [PaymentMethodType.RAZORPAY]?: {
+    [PaymentProvider.RAZORPAY]: {
+      button: PaymentComponentKey;
+    };
+  };
 };
 
 export const lazyPaymentComponentRegistry: PaymentComponentRegistry = {
@@ -306,6 +316,11 @@ export const lazyPaymentComponentRegistry: PaymentComponentRegistry = {
   [PaymentMethodType.CCAVENUE]: {
     [PaymentProvider.CCAVENUE]: {
       button: 'CCAvenueCheckoutButton',
+    },
+  },
+  [PaymentMethodType.RAZORPAY]: {
+    [PaymentProvider.RAZORPAY]: {
+      button: 'RazorpayCheckoutButton',
     },
   },
 };

--- a/packages/react/src/components/checkout/payment/payment-form.tsx
+++ b/packages/react/src/components/checkout/payment/payment-form.tsx
@@ -28,6 +28,7 @@ import GooglePayIcon from '@/components/checkout/payment/icons/GooglePay';
 import MercadoPagoIcon from '@/components/checkout/payment/icons/MercadoPago';
 import PayPalIcon from '@/components/checkout/payment/icons/PayPal';
 import PazeIcon from '@/components/checkout/payment/icons/Paze';
+import RazorpayIcon from '@/components/checkout/payment/icons/Razorpay';
 import {
   hasPaymentMethodButton,
   hasPaymentMethodForm,
@@ -88,6 +89,12 @@ const PAYMENT_METHOD_ICONS: Record<string, React.ReactNode> = {
   mercadopago: <MercadoPagoIcon className='h-5 w-8' />,
   offline: <Wallet className='h-5 w-5' />,
   ccavenue: <CcavenueIcon className='h-5 w-5' />,
+  razorpay: <RazorpayIcon className='h-5 w-5' />,
+};
+
+type SessionPaymentMethodConfig = {
+  processor: AvailablePaymentProviders;
+  checkoutTypes: string[];
 };
 
 export function PaymentForm(
@@ -101,6 +108,7 @@ export function PaymentForm(
     setCheckoutErrors,
     requiredFields,
     godaddyPaymentsConfig,
+    razorpayConfig,
   } = useCheckoutContext();
   const form = useFormContext();
   const paymentMethod = form.watch('paymentMethod');
@@ -131,6 +139,9 @@ export function PaymentForm(
   const countryCode = session?.shipping?.originAddress?.countryCode || 'US';
   const applicationId = getApplicationId(session, godaddyPaymentsConfig?.appId);
   const businessId = godaddyPaymentsConfig?.businessId || session?.businessId;
+  const configuredPaymentMethods = session?.paymentMethods as unknown as
+    | Partial<Record<PaymentMethodValue, SessionPaymentMethodConfig>>
+    | undefined;
 
   // Helper function to get translated payment method labels
   const getPaymentMethodLabel = useCallback(
@@ -154,6 +165,8 @@ export function PaymentForm(
           return t.payment.methods.mercadopago;
         case PaymentMethodType.CCAVENUE:
           return t.payment.methods.ccavenue;
+        case PaymentMethodType.RAZORPAY:
+          return t.payment.methods.razorpay;
         default:
           return key;
       }
@@ -183,6 +196,8 @@ export function PaymentForm(
           return t.payment.descriptions?.mercadopago;
         case PaymentMethodType.CCAVENUE:
           return t.payment.descriptions?.ccavenue;
+        case PaymentMethodType.RAZORPAY:
+          return t.payment.descriptions?.razorpay;
         default:
           return undefined;
       }
@@ -243,9 +258,9 @@ export function PaymentForm(
   const hasGoDaddyAppId = !!applicationId?.trim();
 
   const availablePaymentMethods = React.useMemo(() => {
-    if (!session?.paymentMethods) return [];
-    return Object.keys(session.paymentMethods).filter(key => {
-      const method = session.paymentMethods?.[key as PaymentMethodValue];
+    if (!configuredPaymentMethods) return [];
+    return Object.keys(configuredPaymentMethods).filter(key => {
+      const method = configuredPaymentMethods[key as PaymentMethodValue];
 
       const baseCheck =
         PAYMENT_METHOD_ICONS[key as PaymentMethodValue] &&
@@ -292,14 +307,19 @@ export function PaymentForm(
         return baseCheck && googlePaySupported === true;
       }
 
+      if (key === PaymentMethodType.RAZORPAY) {
+        return baseCheck && !!razorpayConfig?.publicToken;
+      }
+
       return baseCheck;
     });
   }, [
-    session,
+    configuredPaymentMethods,
     hasGoDaddyAppId,
     pazeSupported,
     applePaySupported,
     googlePaySupported,
+    razorpayConfig?.publicToken,
   ]);
 
   const shouldShowBilling =
@@ -457,7 +477,9 @@ export function PaymentForm(
                   {filteredPaymentMethods.map(
                     ([key, { label, icon }], index, array) => {
                       const itemMethodConfig =
-                        session?.paymentMethods?.[key as PaymentMethodValue];
+                        configuredPaymentMethods?.[
+                          key as PaymentMethodValue
+                        ];
                       const itemMethodForm = itemMethodConfig
                         ? getPaymentMethodForm(
                             key as PaymentMethodValue,

--- a/packages/react/src/components/checkout/payment/utils/razorpay-payment-token.test.ts
+++ b/packages/react/src/components/checkout/payment/utils/razorpay-payment-token.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { encodeRazorpayPaymentToken } from './razorpay-payment-token';
+
+describe('encodeRazorpayPaymentToken', () => {
+  it('encodes the versioned handler response as unpadded base64url', () => {
+    const token = encodeRazorpayPaymentToken({
+      v: 1,
+      paymentId: 'pay_29QQoUBi66xm2f',
+      orderId: 'order_9A33XWu170gUtm',
+      signature: '9ef4dffbfd84f1318',
+    });
+
+    expect(token).toMatch(/^[A-Za-z0-9_-]+$/u);
+
+    const base64 = token.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, '=');
+    expect(JSON.parse(atob(padded))).toEqual({
+      v: 1,
+      paymentId: 'pay_29QQoUBi66xm2f',
+      orderId: 'order_9A33XWu170gUtm',
+      signature: '9ef4dffbfd84f1318',
+    });
+  });
+});

--- a/packages/react/src/components/checkout/payment/utils/razorpay-payment-token.ts
+++ b/packages/react/src/components/checkout/payment/utils/razorpay-payment-token.ts
@@ -1,0 +1,21 @@
+export type RazorpayPaymentTokenV1 = {
+  v: 1;
+  paymentId: string;
+  orderId: string;
+  signature: string;
+};
+
+export function encodeRazorpayPaymentToken(
+  payload: RazorpayPaymentTokenV1
+): string {
+  const bytes = new TextEncoder().encode(JSON.stringify(payload));
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+
+  return btoa(binary)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/u, '');
+}

--- a/packages/react/src/components/checkout/payment/utils/use-confirm-checkout.ts
+++ b/packages/react/src/components/checkout/payment/utils/use-confirm-checkout.ts
@@ -87,6 +87,7 @@ export enum PaymentProvider {
   SQUARE = 'SQUARE',
   OFFLINE = 'OFFLINE',
   CCAVENUE = 'CCAVENUE',
+  RAZORPAY = 'RAZORPAY',
 }
 
 export function useConfirmCheckout() {

--- a/packages/react/src/components/checkout/payment/utils/use-get-selected-payment-method.ts
+++ b/packages/react/src/components/checkout/payment/utils/use-get-selected-payment-method.ts
@@ -10,14 +10,16 @@ export function useGetSelectedPaymentMethod(
   return useMemo(() => {
     if (!paymentMethod || !session?.paymentMethods) return null;
 
-    const methodConfig = session.paymentMethods[
-      paymentMethod as PaymentMethodValue
-    ] as PaymentMethodConfig;
+    const paymentMethods = session.paymentMethods as unknown as Partial<
+      Record<PaymentMethodValue, PaymentMethodConfig>
+    >;
+    const methodConfig = paymentMethods[paymentMethod];
+    if (!methodConfig) return null;
 
     return {
       type: paymentMethod,
-      processor: methodConfig?.processor,
-      checkoutTypes: methodConfig?.checkoutTypes || [],
+      processor: methodConfig.processor,
+      checkoutTypes: methodConfig.checkoutTypes || [],
     };
   }, [paymentMethod, session?.paymentMethods]);
 }

--- a/packages/react/src/components/checkout/payment/utils/use-load-razorpay.test.tsx
+++ b/packages/react/src/components/checkout/payment/utils/use-load-razorpay.test.tsx
@@ -1,0 +1,41 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useLoadRazorpay } from './use-load-razorpay';
+
+vi.mock('@/components/checkout/checkout', () => ({
+  useCheckoutContext: () => ({
+    razorpayConfig: { publicToken: 'rzp_test_public' },
+  }),
+}));
+
+describe('useLoadRazorpay', () => {
+  afterEach(() => {
+    document.getElementById('razorpay-sdk')?.remove();
+    Reflect.deleteProperty(window, 'Razorpay');
+  });
+
+  it('loads the Razorpay Checkout SDK once', async () => {
+    const { result } = renderHook(() => useLoadRazorpay());
+    const script = document.getElementById(
+      'razorpay-sdk'
+    ) as HTMLScriptElement | null;
+
+    expect(script?.src).toBe(
+      'https://checkout.razorpay.com/v1/checkout.js'
+    );
+    expect(result.current.isRazorpayLoaded).toBe(false);
+
+    Object.defineProperty(window, 'Razorpay', {
+      configurable: true,
+      value: vi.fn(),
+    });
+    act(() => {
+      script?.dispatchEvent(new Event('load'));
+    });
+
+    await waitFor(() => {
+      expect(result.current.isRazorpayLoaded).toBe(true);
+      expect(result.current.isRazorpayLoadFailed).toBe(false);
+    });
+  });
+});

--- a/packages/react/src/components/checkout/payment/utils/use-load-razorpay.ts
+++ b/packages/react/src/components/checkout/payment/utils/use-load-razorpay.ts
@@ -1,0 +1,90 @@
+import { useEffect, useState } from 'react';
+import { useCheckoutContext } from '@/components/checkout/checkout';
+
+const RAZORPAY_SDK_ID = 'razorpay-sdk';
+const RAZORPAY_SDK_URL = 'https://checkout.razorpay.com/v1/checkout.js';
+
+let isRazorpayLoaded = false;
+let isRazorpayScriptRequested = false;
+const listeners = new Set<(loaded: boolean, failed: boolean) => void>();
+
+function hasRazorpayConstructor() {
+  return typeof (window as Window & { Razorpay?: unknown }).Razorpay === 'function';
+}
+
+function notifyListeners(loaded: boolean, failed: boolean) {
+  listeners.forEach(listener => listener(loaded, failed));
+}
+
+export function useLoadRazorpay() {
+  const { razorpayConfig } = useCheckoutContext();
+  const [loaded, setLoaded] = useState(
+    () => typeof window !== 'undefined' && hasRazorpayConstructor()
+  );
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    const updateState = (nextLoaded: boolean, nextFailed: boolean) => {
+      setLoaded(nextLoaded);
+      setFailed(nextFailed);
+    };
+    listeners.add(updateState);
+
+    if (isRazorpayLoaded || hasRazorpayConstructor()) {
+      isRazorpayLoaded = true;
+      updateState(true, false);
+    }
+
+    return () => {
+      listeners.delete(updateState);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!razorpayConfig?.publicToken || isRazorpayLoaded) return;
+
+    const existingScript = document.getElementById(
+      RAZORPAY_SDK_ID
+    ) as HTMLScriptElement | null;
+
+    if (existingScript) {
+      isRazorpayScriptRequested = true;
+      const handleLoad = () => {
+        isRazorpayLoaded = hasRazorpayConstructor();
+        notifyListeners(isRazorpayLoaded, !isRazorpayLoaded);
+      };
+      const handleError = () => {
+        isRazorpayScriptRequested = false;
+        notifyListeners(false, true);
+      };
+      existingScript.addEventListener('load', handleLoad);
+      existingScript.addEventListener('error', handleError);
+      return () => {
+        existingScript.removeEventListener('load', handleLoad);
+        existingScript.removeEventListener('error', handleError);
+      };
+    }
+
+    if (isRazorpayScriptRequested) return;
+
+    isRazorpayScriptRequested = true;
+    const script = document.createElement('script');
+    script.id = RAZORPAY_SDK_ID;
+    script.src = RAZORPAY_SDK_URL;
+    script.async = true;
+    script.onload = () => {
+      isRazorpayLoaded = hasRazorpayConstructor();
+      notifyListeners(isRazorpayLoaded, !isRazorpayLoaded);
+    };
+    script.onerror = () => {
+      isRazorpayScriptRequested = false;
+      notifyListeners(false, true);
+    };
+    document.body.appendChild(script);
+  }, [razorpayConfig?.publicToken]);
+
+  return {
+    isRazorpayLoaded: loaded,
+    isRazorpayLoadFailed: failed,
+  };
+}

--- a/packages/react/src/components/checkout/utils/checkout-transformers.test.ts
+++ b/packages/react/src/components/checkout/utils/checkout-transformers.test.ts
@@ -12,6 +12,7 @@ const DeliveryMethods = {
 import {
   mapOrderToFormValues,
   mapSkusToItemsDisplay,
+  normalizePhoneForRazorpay,
 } from './checkout-transformers';
 
 type DeepPartial<T> = T extends Array<infer U>
@@ -25,6 +26,26 @@ type DeepPartial<T> = T extends Array<infer U>
 type DraftOrderLineItem = NonNullable<DraftOrder['lineItems']>[number];
 type DraftOrderContact = NonNullable<DraftOrder['shipping']>;
 type DraftOrderAddress = NonNullable<DraftOrderContact['address']>;
+
+describe('normalizePhoneForRazorpay', () => {
+  it('preserves a valid E.164 phone number', () => {
+    expect(normalizePhoneForRazorpay('+442079460958')).toBe('+442079460958');
+  });
+
+  it('normalizes a national number only when its persisted country is known', () => {
+    expect(normalizePhoneForRazorpay('(201) 555-0123', 'US')).toBe(
+      '+12015550123'
+    );
+    expect(normalizePhoneForRazorpay('020 7946 0958', 'GB')).toBe(
+      '+442079460958'
+    );
+    expect(normalizePhoneForRazorpay('(201) 555-0123')).toBeUndefined();
+  });
+
+  it('omits invalid phone input', () => {
+    expect(normalizePhoneForRazorpay('not-a-phone', 'US')).toBeUndefined();
+  });
+});
 
 const money = (value: number, currencyCode = 'USD') => ({
   value,

--- a/packages/react/src/components/checkout/utils/checkout-transformers.ts
+++ b/packages/react/src/components/checkout/utils/checkout-transformers.ts
@@ -42,6 +42,34 @@ function processPhoneNumber(
   }
 }
 
+/**
+ * Normalizes a persisted checkout contact phone for Razorpay prefill.
+ * Unlike the general checkout normalizer, this never assumes a default country.
+ */
+export function normalizePhoneForRazorpay(
+  phoneValue?: string | null,
+  countryCode?: string | null
+): string | undefined {
+  const phone = phoneValue?.trim();
+  if (!phone) return undefined;
+
+  try {
+    const parsed = parsePhoneNumber(phone);
+    if (parsed?.isValid()) return parsed.number;
+  } catch {
+    // A national number requires an explicit persisted country below.
+  }
+
+  if (!countryCode) return undefined;
+
+  try {
+    const parsed = parsePhoneNumber(phone, countryCode as Country);
+    return parsed?.isValid() ? parsed.number : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 type DraftOrderAddress = NonNullable<
   NonNullable<DraftOrder['shipping']>['address']
 >;

--- a/packages/react/src/lib/godaddy/checkout-env.ts
+++ b/packages/react/src/lib/godaddy/checkout-env.ts
@@ -3598,6 +3598,15 @@ const introspection = {
             },
             "args": [],
             "isDeprecated": false
+          },
+          {
+            "name": "razorpay",
+            "type": {
+              "kind": "OBJECT",
+              "name": "CheckoutSessionPaymentMethodConfig"
+            },
+            "args": [],
+            "isDeprecated": false
           }
         ],
         "interfaces": []
@@ -3671,6 +3680,13 @@ const introspection = {
           },
           {
             "name": "paze",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "CheckoutSessionPaymentMethodConfigInput"
+            }
+          },
+          {
+            "name": "razorpay",
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "CheckoutSessionPaymentMethodConfigInput"

--- a/packages/react/src/lib/godaddy/checkout-queries.ts
+++ b/packages/react/src/lib/godaddy/checkout-queries.ts
@@ -138,6 +138,10 @@ export const GetCheckoutSessionQuery = graphql(`
                 processor
                 checkoutTypes
               }
+              razorpay {
+                processor
+                checkoutTypes
+              }
             }
             locations {
               id

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -45,6 +45,7 @@ export const PaymentProvider = {
   OFFLINE: 'offline',
   MERCADOPAGO: 'mercadopago',
   CCAVENUE: 'ccavenue',
+  RAZORPAY: 'razorpay',
 } as const;
 
 export const CheckoutType = {
@@ -67,6 +68,7 @@ export const PaymentMethodType = {
   PAZE: 'paze',
   MERCADOPAGO: 'mercadopago',
   CCAVENUE: 'ccavenue',
+  RAZORPAY: 'razorpay',
 } as const;
 
 // Union of all payment method keys


### PR DESCRIPTION
Wire the C2 checkout UI to authorize, open Razorpay Standard Checkout, encode the signed callback, and confirm, matching the checkout-api contract.

<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changeset

<!--
Help reviewers and the release process by included a changeset entry.
Use `pnpm run changeset` and follow the prompts to create a changeset.
-->

- [ ] Changeset added ([docs](https://github.com/godaddy/javascript#submit-a-changeset))

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->


https://github.com/user-attachments/assets/eb337a18-be9f-4d6a-ac74-604506cd6167




